### PR TITLE
security(wave-2): headers, SSRF, CSRF, CORS, RLS defense-in-depth

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,56 @@
 import type { NextConfig } from "next";
 
+// Wave 2 hardening: security headers on every response.
+//
+// The audit found that HTML routes under /admin/* and /hall/* had zero
+// security headers, leaving the portal exposed to clickjacking, MIME-sniffing,
+// reflected XSS amplification, and HSTS downgrade. vercel.json applied only
+// X-Frame-Options + nosniff to /api/* — not enough.
+//
+// CSP design notes
+//   - 'unsafe-inline' is required for Next/Tailwind's runtime style injection.
+//   - 'unsafe-eval' is unavoidable because Tailwind v4 / some Next dev paths
+//     require it; revisit when those drop the dependency.
+//   - Clerk needs script + frame on its accounts subdomains.
+//   - Supabase storage signed URLs live on *.supabase.co (img + connect).
+//   - frame-ancestors 'none' replaces X-Frame-Options for modern browsers and
+//     covers HTML pages (the prior X-Frame-Options DENY in vercel.json only
+//     applied under /api/*).
+//   - Anthropic + Notion calls happen server-side only, so they don't need
+//     connect-src grants.
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.wearecommonhouse.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.clerk.accounts.dev https://*.clerk.com https://clerk.wearecommonhouse.com",
+  "frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com",
+  "frame-ancestors 'none'",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=(), serial=()" },
+  { key: "Content-Security-Policy", value: csp },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  poweredByHeader: false,
+  async headers() {
+    return [
+      { source: "/:path*", headers: securityHeaders },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/clipper/route.ts
+++ b/src/app/api/clipper/route.ts
@@ -24,21 +24,48 @@ import { buildPersonIndex, resolvePerson, type PersonIndex, type ResolutionReaso
 //  - Bearer token:   Authorization: Bearer <CLIPPER_TOKEN>  (Chrome extension)
 //  - Clerk admin     (fallback if called from portal UI)
 //
-// CORS: open. Bearer/session is the gate.
+// CORS: locked to portal origin + the Chrome extension scheme. The audit
+// flagged that `*` plus a long-lived shared bearer token let any web page
+// attempt to write to /api/clipper from the victim's browser. Per-origin
+// allowlist eliminates that surface.
+const ALLOWED_ORIGINS = new Set<string>([
+  "https://portal.wearecommonhouse.com",
+  "https://common-house-portal.vercel.app",
+  "http://localhost:3000",
+]);
+const ALLOW_EXT_PREFIX = "chrome-extension://";
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin":  "*",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
-  "Access-Control-Max-Age":       "86400",
-};
-
-function corsJson(body: unknown, status = 200) {
-  return NextResponse.json(body, { status, headers: CORS_HEADERS });
+function resolveAllowedOrigin(origin: string | null): string {
+  if (!origin) return "";
+  if (ALLOWED_ORIGINS.has(origin)) return origin;
+  if (origin.startsWith(ALLOW_EXT_PREFIX)) return origin;
+  return "";
 }
 
-export async function OPTIONS() {
-  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+// Set by the POST/OPTIONS entry points at the start of the request so the
+// many deep helpers that call corsJson() don't have to thread `req` through
+// every layer. Re-set on every request; never persisted between requests
+// because module re-use inside the lambda is per-invocation here.
+let _currentOrigin = "";
+
+function corsHeaders(): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin":      _currentOrigin,
+    "Vary":                             "Origin",
+    "Access-Control-Allow-Methods":     "POST, OPTIONS",
+    "Access-Control-Allow-Headers":     "Content-Type, Authorization",
+    "Access-Control-Max-Age":           "86400",
+  };
+}
+
+function corsJson(body: unknown, status = 200) {
+  return NextResponse.json(body, { status, headers: corsHeaders() });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  _currentOrigin = resolveAllowedOrigin(req.headers.get("origin"));
+  if (!_currentOrigin) return new NextResponse(null, { status: 403 });
+  return new NextResponse(null, { status: 204, headers: corsHeaders() });
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -468,6 +495,7 @@ async function handleWhatsappClip(body: ClipBody, req: NextRequest) {
 // ─── Entrypoint ───────────────────────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
+  _currentOrigin = resolveAllowedOrigin(req.headers.get("origin"));
   const authFail = await authorize(req);
   if (authFail) return authFail;
 

--- a/src/app/api/garage-ingest/route.ts
+++ b/src/app/api/garage-ingest/route.ts
@@ -7,6 +7,7 @@ import { adminGuardApi } from "@/lib/require-admin";
 // fan-outs in this route now target Supabase canonical tables.
 import { notion } from "@/lib/notion";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
+import { safeFetch, SsrfBlockedError } from "@/lib/safe-fetch";
 import * as XLSX from "xlsx";
 import mammoth from "mammoth";
 import { extractPptxText } from "@/lib/office-text-extract";
@@ -278,12 +279,18 @@ export async function POST(req: NextRequest) {
   }
 
   // ── Step 1: Download the file ──────────────────────────────────────────────
+  // safeFetch enforces SSRF allowlist: no loopback, no RFC1918, no
+  // 169.254.169.254 metadata, no file://. Without it an admin (or a
+  // compromised admin session) could read the lambda's metadata endpoint.
   let fileBuffer: ArrayBuffer;
   try {
-    const fileRes = await fetch(fileUrl);
+    const fileRes = await safeFetch(fileUrl);
     if (!fileRes.ok) throw new Error(`Download failed: ${fileRes.status}`);
     fileBuffer = await fileRes.arrayBuffer();
   } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return NextResponse.json({ error: "URL rejected by SSRF policy", detail: err.message }, { status: 400 });
+    }
     return NextResponse.json(
       { error: `Failed to download file: ${err instanceof Error ? err.message : String(err)}` },
       { status: 502 }

--- a/src/app/api/garage-upload/finalize/route.ts
+++ b/src/app/api/garage-upload/finalize/route.ts
@@ -9,6 +9,21 @@ import { notion, DB } from "@/lib/notion";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { classifyFile } from "../classify";
 
+// Storage path validation — admins POST the storagePath back from the client,
+// so without this check an attacker with an admin session could ask for a
+// signed read URL on any path in any bucket the service-role key can see
+// (e.g. ../inbox-captures/foo.png). Lock the path to garage/ prefix and
+// reject any traversal or NUL byte tricks.
+function assertGarageStoragePath(path: string): void {
+  if (typeof path !== "string" || !path) throw new Error("storagePath required");
+  if (path.length > 512) throw new Error("storagePath too long");
+  if (/[\x00-\x1f\x7f]/.test(path)) throw new Error("storagePath contains control characters");
+  if (path.includes("..")) throw new Error("storagePath contains traversal");
+  if (path.startsWith("/") || path.startsWith("\\")) throw new Error("storagePath must be relative");
+  // Bucket is `garage-docs`, conventional prefix is `garage/` per garage-upload route.
+  if (!path.startsWith("garage/")) throw new Error("storagePath must be under garage/");
+}
+
 function getSupabase() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -75,6 +90,7 @@ export async function POST(req: NextRequest) {
 
   for (const upload of uploads) {
     try {
+      assertGarageStoragePath(upload.storagePath);
       // Create a long-lived signed read URL
       const supabase = getSupabase();
       const { data: signedData, error: urlError } = await supabase.storage

--- a/src/app/api/garage-upload/route.ts
+++ b/src/app/api/garage-upload/route.ts
@@ -27,13 +27,21 @@ export async function POST(req: NextRequest) {
   if (!projectId || !files?.length)
     return NextResponse.json({ error: "projectId and files required" }, { status: 400 });
 
+  // projectId is interpolated into the storage path — without shape validation an
+  // admin could pass "../something/" and write into a sibling bucket prefix.
+  // Notion page IDs are 32 hex chars (with or without dashes); allow both.
+  if (!/^[0-9a-fA-F-]{32,36}$/.test(projectId)) {
+    return NextResponse.json({ error: "projectId must be a valid uuid or notion page id" }, { status: 400 });
+  }
+
   const supabase = getSupabase();
   const results: { name: string; storagePath: string; signedUrl: string; error?: string }[] = [];
 
   for (const file of files) {
     // Sanitize filename — spaces and special chars break Supabase storage paths
     const safeName = file.name.replace(/[^a-zA-Z0-9.\-_]/g, "_");
-    const storagePath = `${projectId}/${Date.now()}-${Math.random().toString(36).slice(2, 6)}-${safeName}`;
+    // Prefix `garage/` so the finalize route's allowlist check holds.
+    const storagePath = `garage/${projectId}/${Date.now()}-${Math.random().toString(36).slice(2, 6)}-${safeName}`;
     const { data, error } = await supabase.storage
       .from("garage-docs")
       .createSignedUploadUrl(storagePath);

--- a/src/app/api/google/auth/route.ts
+++ b/src/app/api/google/auth/route.ts
@@ -122,9 +122,14 @@ export async function GET(req: NextRequest) {
     parsed_scope_param,
   }));
 
-  // Allow ?go=1 to actually redirect (so we can complete the flow once we
-  // have verified the values). Default is diagnostic JSON.
-  if (req.nextUrl.searchParams.get("go") === "1") {
+  // Always redirect in production. Diagnostic mode (JSON dump of env, headers,
+  // and client_id suffix) is restricted to non-production environments or to
+  // explicit opt-in via GOOGLE_AUTH_DEBUG=1. The previous behaviour exposed
+  // env_override values, redirect URI char codes, and last-12 of client_id
+  // to anyone with an admin session — strictly unnecessary in prod.
+  const debugEnabled = process.env.NODE_ENV !== "production"
+    || process.env.GOOGLE_AUTH_DEBUG === "1";
+  if (!debugEnabled || req.nextUrl.searchParams.get("go") === "1") {
     return NextResponse.redirect(auth_url);
   }
 

--- a/src/app/api/library/ingest-to-tree/route.ts
+++ b/src/app/api/library/ingest-to-tree/route.ts
@@ -35,6 +35,9 @@ import mammoth from "mammoth";
 import { randomUUID } from "node:crypto";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { adminGuardApi } from "@/lib/require-admin";
+import { safeFetch } from "@/lib/safe-fetch";
+import { requireSameOriginRequest } from "@/lib/require-same-origin";
+import { isValidCronRequest } from "@/lib/require-cron";
 import {
   canonicaliseCaseCode,
   generateTypedCaseCode,
@@ -137,7 +140,8 @@ async function extractText(file: File): Promise<{ text: string; pdfBase64?: stri
 }
 
 async function fetchUrlAsText(url: string): Promise<string> {
-  const res = await fetch(url, { headers: { "User-Agent": "Mozilla/5.0 CommonHouse-Ingest" } });
+  // safeFetch enforces SSRF allowlist (no loopback / RFC1918 / metadata).
+  const res = await safeFetch(url, { headers: { "User-Agent": "Mozilla/5.0 CommonHouse-Ingest" } });
   if (!res.ok) throw new Error(`URL fetch failed: ${res.status}`);
   const html = await res.text();
   // Minimal strip-to-text — remove scripts/styles, collapse whitespace
@@ -152,6 +156,11 @@ async function fetchUrlAsText(url: string): Promise<string> {
 }
 
 async function _POST(req: NextRequest) {
+  // Cron paths bypass CSRF (server-to-server). Browser paths must be same-origin.
+  if (!isValidCronRequest(req)) {
+    const csrf = requireSameOriginRequest(req);
+    if (csrf) return csrf;
+  }
   if (!(await isAuthorized(req))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/projects/[id]/proposal-upload/route.ts
+++ b/src/app/api/projects/[id]/proposal-upload/route.ts
@@ -16,6 +16,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { adminGuardApi } from "@/lib/require-admin";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
+import { requireSameOriginRequest } from "@/lib/require-same-origin";
 import type { HallDraft } from "@/lib/hall-compose";
 
 export const dynamic = "force-dynamic";
@@ -50,12 +51,19 @@ export async function POST(
   req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
 ) {
+  const csrf = requireSameOriginRequest(req);
+  if (csrf) return csrf;
   const guard = await adminGuardApi();
   if (guard) return guard;
 
   const { id: projectId } = await ctx.params;
   if (!projectId) {
     return NextResponse.json({ ok: false, error: "missing project id" }, { status: 400 });
+  }
+  // Path traversal hardening: projectId is interpolated into the storage path.
+  // Accept only uuid / Notion page id shapes.
+  if (!/^[0-9a-fA-F-]{32,36}$/.test(projectId)) {
+    return NextResponse.json({ ok: false, error: "invalid project id" }, { status: 400 });
   }
 
   let file: File | null = null;

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { uploadFileToDrive, FolderName } from "@/lib/drive";
+import { requireSameOriginRequest } from "@/lib/require-same-origin";
 // notion-cutoff-2026-06-02: Notion `Sources` write removed; canonical write is now to `sources` (Supabase).
 // import { notion, DB } from "@/lib/notion";
 import { getProjectIdForUser, getClientConfig, isAdminUser, isAdminEmail } from "@/lib/clients";
@@ -11,6 +12,11 @@ const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
 
 export async function POST(req: NextRequest) {
   try {
+    // CSRF: multipart routes lack the implicit CORS preflight that JSON routes get,
+    // so reject any cross-origin POST.
+    const csrf = requireSameOriginRequest(req);
+    if (csrf) return csrf;
+
     const user = await currentUser();
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     const email = user.primaryEmailAddress?.emailAddress ?? "";

--- a/src/lib/require-same-origin.ts
+++ b/src/lib/require-same-origin.ts
@@ -1,0 +1,28 @@
+/**
+ * CSRF defense for multipart / form-encoded routes.
+ *
+ * Why this exists: routes that accept multipart/form-data (uploads) and rely
+ * only on Clerk cookie auth are CSRF-exposed when Clerk's SameSite is `lax`
+ * — an attacker-hosted form POST will attach the cookie. JSON routes get
+ * implicit protection via CORS preflight; multipart does not.
+ *
+ * Defense:
+ *   1. Modern browsers send Sec-Fetch-Site = same-origin on first-party POSTs
+ *      and `cross-site` on attacker-driven ones. We accept only same-origin.
+ *   2. Older browsers and non-browser clients (e.g. internal scripts) can pass
+ *      `x-csrf-portal: 1` instead — any custom header forces a CORS preflight
+ *      that the attacker origin cannot satisfy.
+ */
+
+import { NextResponse } from "next/server";
+
+export function requireSameOriginRequest(req: Request): NextResponse | null {
+  const fetchSite = req.headers.get("sec-fetch-site");
+  if (fetchSite === "same-origin" || fetchSite === "same-site") return null;
+  // Older browsers don't send Sec-Fetch-Site at all. They can opt in via the
+  // custom header — sending a custom header triggers a CORS preflight which an
+  // attacker page cannot satisfy from a different origin.
+  if (req.headers.get("x-csrf-portal") === "1") return null;
+  // No Sec-Fetch-Site header AND no custom header → reject as cross-origin.
+  return NextResponse.json({ error: "Cross-origin request blocked" }, { status: 403 });
+}

--- a/src/lib/safe-fetch.ts
+++ b/src/lib/safe-fetch.ts
@@ -1,0 +1,130 @@
+/**
+ * SSRF-safe fetch wrapper.
+ *
+ * Why: routes like /api/garage-ingest and /api/library/ingest-to-tree accept
+ * a URL or storagePath from admin input and fetch it server-side. Without
+ * filtering, an admin (or a compromised admin session) can point the lambda
+ * at cloud metadata services (169.254.169.254), internal RFC1918 ranges,
+ * loopback, or non-http schemes like file:// — leaking secrets or enabling
+ * lateral movement.
+ *
+ * Rules enforced:
+ *   - scheme must be http or https
+ *   - hostname (after DNS resolution when possible) must NOT be:
+ *     - loopback (127.0.0.0/8, ::1, 0.0.0.0)
+ *     - link-local (169.254.0.0/16) — covers AWS/GCP metadata at .169.254
+ *     - RFC1918 private (10/8, 172.16/12, 192.168/16)
+ *     - RFC4193 unique local (fc00::/7)
+ *   - redirects: caller must opt in. By default we follow up to 3 redirects
+ *     and re-validate each hop's destination.
+ */
+
+import { lookup } from "node:dns/promises";
+
+class SsrfBlockedError extends Error {
+  constructor(reason: string) {
+    super(`SSRF blocked: ${reason}`);
+    this.name = "SsrfBlockedError";
+  }
+}
+
+function isPrivateOrLoopbackIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some(p => isNaN(p) || p < 0 || p > 255)) return true;
+  const [a, b] = parts;
+  // 0/8, 10/8, 127/8 reserved/private/loopback
+  if (a === 0 || a === 10 || a === 127) return true;
+  // 169.254/16 link-local (covers cloud metadata 169.254.169.254)
+  if (a === 169 && b === 254) return true;
+  // 172.16/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168/16
+  if (a === 192 && b === 168) return true;
+  // 100.64/10 carrier-grade NAT (sometimes used internally)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
+function isPrivateOrLoopbackIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === "::1" || lower === "::") return true;
+  // fc00::/7 unique local
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  // fe80::/10 link-local
+  if (lower.startsWith("fe80")) return true;
+  // IPv4-mapped IPv6 (::ffff:1.2.3.4) — extract IPv4 and re-check
+  const v4mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4mapped) return isPrivateOrLoopbackIPv4(v4mapped[1]);
+  return false;
+}
+
+async function assertHostnameSafe(hostname: string): Promise<void> {
+  if (!hostname) throw new SsrfBlockedError("empty hostname");
+
+  // Reject bracketed/raw IPs that match private ranges without needing DNS.
+  const bare = hostname.replace(/^\[|\]$/g, "");
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(bare)) {
+    if (isPrivateOrLoopbackIPv4(bare)) throw new SsrfBlockedError(`private IPv4 ${bare}`);
+    return; // public IPv4 literal is allowed
+  }
+  if (bare.includes(":")) {
+    if (isPrivateOrLoopbackIPv6(bare)) throw new SsrfBlockedError(`private IPv6 ${bare}`);
+    return;
+  }
+
+  // Localhost shortcut
+  if (bare === "localhost" || bare.endsWith(".localhost")) {
+    throw new SsrfBlockedError("localhost");
+  }
+
+  // DNS-resolve and verify every returned record is public.
+  let records: { address: string; family: number }[];
+  try {
+    records = await lookup(bare, { all: true });
+  } catch {
+    throw new SsrfBlockedError(`dns resolution failed for ${bare}`);
+  }
+  for (const r of records) {
+    const bad = r.family === 4
+      ? isPrivateOrLoopbackIPv4(r.address)
+      : isPrivateOrLoopbackIPv6(r.address);
+    if (bad) throw new SsrfBlockedError(`resolved to private address ${r.address}`);
+  }
+}
+
+export interface SafeFetchOptions extends RequestInit {
+  /** Max redirects to follow. Each hop is re-validated. Default 3. */
+  maxRedirects?: number;
+}
+
+/**
+ * fetch() but with SSRF guards. Throws SsrfBlockedError if the destination
+ * fails the safety checks. All other errors propagate normally.
+ */
+export async function safeFetch(url: string, options: SafeFetchOptions = {}): Promise<Response> {
+  const { maxRedirects = 3, ...init } = options;
+  let current = url;
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    let parsed: URL;
+    try {
+      parsed = new URL(current);
+    } catch {
+      throw new SsrfBlockedError(`invalid URL ${current}`);
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new SsrfBlockedError(`disallowed scheme ${parsed.protocol}`);
+    }
+    await assertHostnameSafe(parsed.hostname);
+
+    const res = await fetch(current, { ...init, redirect: "manual" });
+    if (res.status >= 300 && res.status < 400 && res.headers.has("location")) {
+      const next = new URL(res.headers.get("location")!, current).toString();
+      current = next;
+      continue;
+    }
+    return res;
+  }
+  throw new SsrfBlockedError(`too many redirects (>${maxRedirects})`);
+}
+
+export { SsrfBlockedError };

--- a/supabase/migrations/20260511120000_rls_defense_in_depth.sql
+++ b/supabase/migrations/20260511120000_rls_defense_in_depth.sql
@@ -1,0 +1,36 @@
+-- Wave 2.5 — RLS defense-in-depth.
+--
+-- The audit found that 87 of 90 Supabase tables have RLS enabled but no
+-- policies attached, meaning anon and authenticated roles get DENY by default.
+-- Today the app is safe only because no client-side code imports
+-- @supabase/supabase-js with the anon key — but a single future import would
+-- expose every table to anon attempts.
+--
+-- This migration adds an explicit REVOKE so even if RLS were accidentally
+-- disabled on a table (e.g. via the Supabase Studio UI), anon/authenticated
+-- would still be denied. The service_role bypasses RLS regardless and keeps
+-- working as before.
+--
+-- We do NOT add USING-clause policies here because there are no use cases
+-- yet for letting end-users read data directly. When such a use case appears,
+-- add a granular policy alongside (or instead of) this revoke.
+
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOR tbl IN
+    SELECT tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT LIKE 'pg_%'
+      AND tablename NOT LIKE 'auth_%'
+  LOOP
+    EXECUTE format('REVOKE ALL ON TABLE public.%I FROM anon', tbl);
+    EXECUTE format('REVOKE ALL ON TABLE public.%I FROM authenticated', tbl);
+  END LOOP;
+END $$;
+
+-- Future tables: enforce the same posture by default.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM anon;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM authenticated;


### PR DESCRIPTION
Wave 2 of the 5-wave remediation plan. All HIGH and MEDIUM hardening items from the external-attacker audit that don't require breaking schema changes. No new functionality.

Headers (audit H6)
- next.config.ts grows a full security-headers function: Strict-Transport-Security, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and a Content-Security-Policy scoped to Clerk + Supabase. frame-ancestors 'none' replaces the prior X-Frame-Options that only applied under /api/*, blocking clickjacking on /admin/* and /hall/*. poweredByHeader off.

SSRF (audit H3)
- New src/lib/safe-fetch.ts wraps fetch() with a host allowlist that rejects loopback, RFC1918, RFC4193, 169.254/16 (covers AWS/GCP metadata at 169.254.169.254), and non-http(s) schemes. Resolves DNS before fetching and re-validates every redirect hop.
- Applied to /api/garage-ingest (fileUrl download) and /api/library/ingest-to-tree (URL ingest) — the two routes that fetched admin-supplied URLs without filtering.

Storage path validation (audit H4)
- /api/garage-upload now requires projectId to match a uuid / Notion page id shape before interpolating it into the storage path. Storage path prefix moved to `garage/{projectId}/...` so the finalize route's allowlist can enforce it.
- /api/garage-upload/finalize rejects any storagePath that contains '..', control characters, leading slash, or isn't under `garage/`.
- /api/projects/[id]/proposal-upload validates projectId shape before interpolating it into `proposals/{projectId}/...`.

CSRF defense for multipart uploads (audit H7)
- New src/lib/require-same-origin.ts: accepts only requests with Sec-Fetch-Site = same-origin (modern browsers) OR the explicit X-CSRF-Portal: 1 opt-in. Cross-origin form POSTs (the classic CSRF vector for multipart routes that bypass CORS preflight) are blocked before auth runs.
- Applied to /api/upload, /api/projects/[id]/proposal-upload, and /api/library/ingest-to-tree (CRON_SECRET callers bypass the check since they aren't browser-driven).

Clipper CORS lockdown (audit H8)
- Removed Access-Control-Allow-Origin: *. Per-origin allowlist now echoes only portal.wearecommonhouse.com, the vercel.app preview, the localhost dev origin, and chrome-extension://* (since the clipper extension is the legitimate non-browser caller). OPTIONS returns 403 for disallowed origins.

OAuth diagnostic mode (audit M4)
- /api/google/auth's JSON-dump diagnostic response (last-12 of client_id, redirect URI char codes, env values, request headers) is now gated behind NODE_ENV !== production OR GOOGLE_AUTH_DEBUG=1. Production always redirects, eliminating the admin-only info-leak surface.

RLS defense-in-depth (audit M9)
- New migration 20260511120000_rls_defense_in_depth.sql does a blanket REVOKE on anon + authenticated for every public table, and sets the same as the default privilege for future tables. RLS itself is unchanged — this just adds belt-and-braces so that even if RLS were accidentally disabled, the two non-service roles would still be denied. service_role bypasses RLS and is unaffected.

Out of scope for Wave 2 (tracked for Wave 3)
- Rate limiting on Anthropic-calling routes
- import "server-only" markers
- Logging hygiene wrapper (err.message echoes)
- Supabase service→anon fallback observability
- Decompression-bomb guard in JSZip path
- Chrome extension hardening (apiUrl user-configurable)
- target=_blank rel=noopener sweep
- Remaining d3-color / postcss transitive CVEs