### PR TITLE
fix(hall): null-safe notion_id link in OppRow + Portfolio row

### DIFF
--- a/src/components/HallOppFreshnessRadar.tsx
+++ b/src/components/HallOppFreshnessRadar.tsx
@@ -83,7 +83,7 @@ type RawOpp = {
 };
 
 type ColdOpp = {
-  id: string;
+  id: string | null;
   title: string;
   orgName: string | null;
   type: string | null;
@@ -112,7 +112,7 @@ export async function HallOppFreshnessRadar() {
 
   return (
     <ul className="flex flex-col">
-      {opps.map(o => <OppRow key={o.id} opp={o} />)}
+      {opps.map((o, i) => <OppRow key={o.id ?? `idx-${i}`} opp={o} />)}
     </ul>
   );
 }
@@ -121,10 +121,15 @@ function OppRow({ opp }: { opp: ColdOpp }) {
   const ageColor = opp.daysStale >= 30 ? "var(--hall-danger)"
     : opp.daysStale >= 14 ? "var(--hall-warn)"
     : "var(--hall-muted-3)";
+  // Some opportunities have no notion_id (Supabase-native rows). Fall back
+  // to reviewUrl alone — if both are missing the row links nowhere, which
+  // is fine; it never crashes the page.
+  const href = opp.reviewUrl
+    ?? (opp.id ? `https://www.notion.so/${opp.id.replace(/-/g, "")}` : "#");
   return (
     <li style={{ borderTop: "1px solid var(--hall-line-soft)" }}>
       <a
-        href={opp.reviewUrl ?? `https://www.notion.so/${opp.id.replace(/-/g, "")}`}
+        href={href}
         target="_blank"
         rel="noopener noreferrer"
         className="flex items-start gap-3 py-2.5 transition-colors"

--- a/src/components/HallPortfolioPulse.tsx
+++ b/src/components/HallPortfolioPulse.tsx
@@ -144,7 +144,7 @@ function PulseRow({ entry }: { entry: PortfolioEntry }) {
   return (
     <li style={{ borderTop: "1px solid var(--hall-line-soft)" }}>
       <a
-        href={`https://www.notion.so/${p.notion_id.replace(/-/g, "")}`}
+        href={p.notion_id ? `https://www.notion.so/${p.notion_id.replace(/-/g, "")}` : "#"}
         target="_blank"
         rel="noopener noreferrer"
         className="flex items-center gap-3 py-2.5"


### PR DESCRIPTION
## Root cause

`debug_log` capture after PR #21 landed (with the new `instrumentation.onRequestError` hook surfacing the real stack):

```
TypeError: Cannot read properties of null (reading 'replace')
  at x (.next/server/chunks/ssr/src_0kk8du-._.js:1:23628)
  at Array.toJSON ... at stringify
  at ... at react-server-components prop serialization
```

The `x` function is `OppRow`'s href computation:
```tsx
href={opp.reviewUrl ?? `https://www.notion.so/${opp.id.replace(/-/g, "")}`}
```

8 of 39 active opportunities have `notion_id = NULL` (Supabase-native rows that never carried a Notion ID). When both `reviewUrl` and `notion_id` are null, `.replace()` on null crashes the page.

## Why SafeServerSection (PR #21) didn't catch this

The wrapper awaits `HallOppFreshnessRadar()` but the throw happens inside `<OppRow>`, which React invokes *after* the wrapper has returned the JSX tree — outside the try/catch.

## Fix

Make the child null-safe at the source:
```tsx
const href = opp.reviewUrl
  ?? (opp.id ? `https://www.notion.so/${opp.id.replace(/-/g, "")}` : "#");
```
Same pattern applied to `HallPortfolioPulse.tsx` (preventive — not currently mounted but the bug would surface the moment it is).

## Test plan
- [ ] Vercel preview deploys clean
- [ ] After merge, open `https://portal.wearecommonhouse.com/admin` (no query string)
- [ ] Full Hall renders without hitting `error.tsx`
- [ ] Confirm `debug_log` has no new `admin/error.tsx` rows


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXQ52bGfpGSjV2njYCk7a)_