### PR TITLE
fix(hall): dismiss = permanente across all surfaces (L-011/L-012/L-013)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -66,6 +66,7 @@ import { ADMIN_NAV } from "@/lib/admin-nav";
 import { requireAdmin } from "@/lib/require-admin";
 import { TriggerBriefingButton } from "@/components/TriggerBriefingButton";
 import { ReadyForJoseSection } from "@/components/ReadyForJoseSection";
+import { getDismissedDraftIds } from "@/lib/hall-draft-dismissals";
 import { SuggestedTimeBlocks } from "@/components/SuggestedTimeBlocks";
 import { HallManualTriggers } from "@/components/HallManualTriggers";
 import { HallLiveClock } from "@/components/HallLiveClock";
@@ -807,8 +808,19 @@ export default async function AdminPage({ searchParams }: { searchParams?: Promi
   // Market Signal and other system-generated signals are excluded: they have no
   // Jose-facing next action. "Approved" on those means the agent approved its own output.
   const RFJ_TYPES = new Set(["Follow-up Email", "Check-in Email", "LinkedIn Post", "Grant Brief", "Grant Application Draft"]);
-  const rfjGmailDrafts    = gmailDrafts.filter(d => RFJ_TYPES.has(d.draftType));
-  const rfjApprovedDrafts = approvedDrafts.filter(d => RFJ_TYPES.has(d.draftType));
+  // L-011: server-side filter for Ready-for-Jose dismisses. Load the set
+  // of draft_notion_ids this user permanently dismissed and drop them
+  // before rendering. Best-effort: an internal failure logs but doesn't
+  // crash the page.
+  let dismissedDraftIds: Set<string>;
+  try {
+    dismissedDraftIds = await getDismissedDraftIds(adminUser.id);
+  } catch (e) {
+    await logServerError("admin/page:loader:getDismissedDraftIds", e);
+    dismissedDraftIds = new Set();
+  }
+  const rfjGmailDrafts    = gmailDrafts.filter(d => RFJ_TYPES.has(d.draftType) && !dismissedDraftIds.has(d.id));
+  const rfjApprovedDrafts = approvedDrafts.filter(d => RFJ_TYPES.has(d.draftType) && !dismissedDraftIds.has(d.id));
 
   // ── Derived state ────────────────────────────────────────────────────────────
   const withBlockers    = projects.filter(p => p.blockerCount > 0);

--- a/src/app/api/agent-drafts/dismiss/route.ts
+++ b/src/app/api/agent-drafts/dismiss/route.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/agent-drafts/dismiss
+ *
+ * Persists an agent-draft dismiss per (draft_notion_id, user_id) to
+ * public.hall_draft_dismissals. Replaces the prior client-only
+ * `localStorage` 24h TTL — see L-011 in tasks/lessons.md.
+ *
+ * Body: { draft_id: string }  (the notion_id / draft id rendered in the Hall)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { adminGuardApi } from "@/lib/require-admin";
+import { getSupabaseServerClient } from "@/lib/supabase-server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const guard = await adminGuardApi();
+  if (guard) return guard;
+
+  const user = await currentUser();
+  if (!user?.id) return NextResponse.json({ error: "no_user" }, { status: 401 });
+
+  let body: { draft_id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const draftId = (body.draft_id ?? "").trim();
+  if (!draftId) return NextResponse.json({ error: "draft_id required" }, { status: 400 });
+
+  const sb = getSupabaseServerClient();
+  const { error } = await sb.from("hall_draft_dismissals").upsert({
+    draft_notion_id: draftId,
+    user_id: user.id,
+    dismissed_at: new Date().toISOString(),
+    dismissed_by: user.primaryEmailAddress?.emailAddress ?? null,
+  }, { onConflict: "draft_notion_id,user_id" });
+
+  if (error) return NextResponse.json({ error: "persist_failed" }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/suggested-time-blocks/route.ts
+++ b/src/app/api/suggested-time-blocks/route.ts
@@ -157,7 +157,12 @@ export async function GET(_req: NextRequest) {
     const prepCands      = await candidatesFromMeetings(upcoming, now, attendeeLookup);
     const followUpCands  = candidatesFromRecentMeetings(recent, now, attendeeLookup);
 
-    // Fingerprint blacklist: dismissed in last 24h, snoozed until future
+    // L-011 fix: dismissed fingerprints are suppressed FOREVER. The previous
+    // 24h cutoff meant the same loop reappeared every day after dismiss —
+    // the user reported dismissing the same suggestion 5x in 16 days.
+    // A new fingerprint (new loop / new content) is the only legitimate
+    // resurrection path; same fingerprint must stay buried.
+    // Snoozed fingerprints still respect their snoozed_until (by design).
     const { data: blocks } = await sb
       .from("suggested_time_blocks")
       .select("fingerprint,status,dismissed_at,snoozed_until")
@@ -165,9 +170,8 @@ export async function GET(_req: NextRequest) {
       .in("status", ["dismissed", "snoozed"]);
 
     const suppressed = new Set<string>();
-    const cutoff = Date.now() - 24 * 3600_000;
     for (const r of (blocks ?? []) as { fingerprint: string; status: string; dismissed_at: string | null; snoozed_until: string | null }[]) {
-      if (r.status === "dismissed" && r.dismissed_at && new Date(r.dismissed_at).getTime() > cutoff) {
+      if (r.status === "dismissed" && r.dismissed_at) {
         suppressed.add(r.fingerprint);
       } else if (r.status === "snoozed" && r.snoozed_until && new Date(r.snoozed_until).getTime() > Date.now()) {
         suppressed.add(r.fingerprint);

--- a/src/components/ReadyForJoseSection.tsx
+++ b/src/components/ReadyForJoseSection.tsx
@@ -1,37 +1,23 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { AgentDraft } from "@/lib/notion";
 
-// Dismissals expire after 24 hours so completed items don't pile up permanently
-const DISMISS_TTL_MS = 24 * 60 * 60 * 1000;
-const STORAGE_KEY = "rfj_dismissed_v1";
-
-function loadDismissed(): Set<string> {
-  if (typeof window === "undefined") return new Set();
+// L-011 fix: dismiss is permanent and server-persisted. The previous
+// implementation was localStorage with a 24h TTL — drafts reappeared on
+// a different browser, after clearing cache, or after a day. The server
+// now records `(draft_notion_id, user_id)` in `hall_draft_dismissals`
+// and /admin/page.tsx filters by it before rendering.
+async function persistDismiss(draftId: string): Promise<void> {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return new Set();
-    const parsed: Record<string, number> = JSON.parse(raw);
-    const now = Date.now();
-    const active = Object.entries(parsed)
-      .filter(([, ts]) => now - ts < DISMISS_TTL_MS)
-      .map(([id]) => id);
-    return new Set(active);
+    await fetch("/api/agent-drafts/dismiss", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ draft_id: draftId }),
+    });
   } catch {
-    return new Set();
-  }
-}
-
-function saveDismiss(id: string) {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    const parsed: Record<string, number> = raw ? JSON.parse(raw) : {};
-    parsed[id] = Date.now();
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
-  } catch {
-    /* ignore */
+    /* best-effort — router.refresh() will fetch the server-truth anyway */
   }
 }
 
@@ -60,17 +46,14 @@ export function ReadyForJoseSection({
   approvedDrafts: AgentDraft[]; // status === "Approved"       — ready to push to Gmail
 }) {
   const router = useRouter();
+  // Optimistic local hide for the immediate frame; the server filter
+  // (hall_draft_dismissals) is the source of truth on the next render.
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
   const [states, setStates] = useState<Record<string, ItemState>>({});
 
-  // Hydrate from localStorage after mount (avoids SSR mismatch)
-  useEffect(() => {
-    setDismissed(loadDismissed());
-  }, []);
-
   function dismiss(id: string) {
-    saveDismiss(id);
     setDismissed((prev) => new Set([...prev, id]));
+    persistDismiss(id).then(() => router.refresh());
   }
 
   async function pushToGmail(draft: AgentDraft) {

--- a/src/lib/hall-draft-dismissals.ts
+++ b/src/lib/hall-draft-dismissals.ts
@@ -1,0 +1,28 @@
+/**
+ * Reader for `public.hall_draft_dismissals` — the server-side filter that
+ * makes Ready-for-Jose dismisses permanent across browsers and sessions.
+ * Used by /admin/page.tsx to drop dismissed drafts before passing them to
+ * <ReadyForJoseSection>. See L-011 / L-013 in tasks/lessons.md.
+ */
+
+import { getSupabaseServerClient } from "@/lib/supabase-server";
+
+/** Returns the set of draft notion_ids the given user has dismissed. */
+export async function getDismissedDraftIds(userId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  if (!userId) return ids;
+  try {
+    const sb = getSupabaseServerClient();
+    const { data } = await sb
+      .from("hall_draft_dismissals")
+      .select("draft_notion_id")
+      .eq("user_id", userId);
+    for (const r of (data ?? []) as { draft_notion_id: string }[]) {
+      if (r.draft_notion_id) ids.add(r.draft_notion_id);
+    }
+  } catch {
+    // best-effort — caller will fall back to empty Set and one dismissed
+    // draft may reappear once. Far better than crashing /admin.
+  }
+  return ids;
+}

--- a/src/lib/pipeline-state.ts
+++ b/src/lib/pipeline-state.ts
@@ -145,7 +145,7 @@ type DecisionItemRow = {
   due_date: string | null;
 };
 
-type SnoozeRow = { entity_type: string; entity_id: string; until_at: string };
+type SnoozeRow = { entity_type: string; entity_id: string; until_at: string; snoozed_at: string | null };
 
 type LogRow = {
   id: string;
@@ -208,7 +208,7 @@ export async function getPipelineState(): Promise<PipelineStateResult> {
           .select("id, title, status, priority, org_notion_id, due_date")
           .in("org_notion_id", orgIdsArr)
           .in("status", ["Open", "Pending", "Pending Review", "In Progress"]),
-    sb.from("hall_snoozes").select("entity_type, entity_id, until_at").gt("until_at", new Date().toISOString()),
+    sb.from("hall_snoozes").select("entity_type, entity_id, until_at, snoozed_at").gt("until_at", new Date().toISOString()),
     sb.from("hall_attention_log").select("id, entity_type, entity_id, reason, surfaced_at, resolved_at, resolution"),
     orgIdsArr.length === 0
       ? Promise.resolve({ data: [] })
@@ -268,7 +268,12 @@ export async function getPipelineState(): Promise<PipelineStateResult> {
   const aiByOrg = groupBy(actionItems, r => r.org_notion_id);
   const decByOrg = groupBy(decisions, r => r.org_notion_id);
   const snoozeKey = (t: string, id: string) => `${t}:${id}`;
-  const snoozedSet = new Set(snoozes.map(s => snoozeKey(s.entity_type, s.entity_id)));
+  // L-011: dismiss = forever; única resurrección legítima = nueva señal posterior.
+  // Map keeps `snoozed_at` so the reader can auto-lift the snooze when an
+  // inbound email / transcript / signal lands AFTER the snooze. Without
+  // this, a dismiss-forever would bury a re-engaged opportunity.
+  const snoozedAtByKey = new Map<string, string | null>();
+  for (const s of snoozes) snoozedAtByKey.set(snoozeKey(s.entity_type, s.entity_id), s.snoozed_at);
   const openLogByKey = new Map<string, LogRow>();
   const closedLogByKey = new Map<string, LogRow>();
   for (const l of logs) {
@@ -330,13 +335,23 @@ export async function getPipelineState(): Promise<PipelineStateResult> {
   const surfaced: Surfaced[] = [];
 
   for (const cand of candidates) {
-    if (snoozedSet.has(snoozeKey(cand.entityType, cand.entityId))) continue;
-
     const ais = (cand.orgNotionId ? aiByOrg.get(cand.orgNotionId) : undefined) ?? [];
     const dis = (cand.orgNotionId ? decByOrg.get(cand.orgNotionId) : undefined) ?? [];
     const peopleAct = (cand.orgNotionId ? peopleActByOrg.get(cand.orgNotionId) : undefined) ?? [];
     const lastInbound = maxIso(peopleAct.flatMap(p => [p.last_email_at, p.last_transcript_at]));
     const lastSignal = cand.oppRow?.last_signal_at ?? lastInbound;
+
+    // L-011 auto-lift: a snoozed entity becomes visible again ONLY when a
+    // fresh signal arrives after the snooze (inbound email / transcript /
+    // opp signal). Without a newer signal the snooze stands, including
+    // the dismiss-forever sentinel (until_at = 9999-12-31). This is what
+    // lets "Acknowledge — not pursuing" be truly permanent without
+    // burying an opportunity that genuinely re-engages.
+    const snoozedAt = snoozedAtByKey.get(snoozeKey(cand.entityType, cand.entityId));
+    if (snoozedAt !== undefined) {
+      const reactivated = !!(lastSignal && new Date(lastSignal) > new Date(snoozedAt ?? 0));
+      if (!reactivated) continue;
+    }
 
     const ballJose = computeBallWithJose(ais, dis, now);
     const ballThem = computeBallWithThem(ais, now);
@@ -589,9 +604,40 @@ export async function snoozeEntity(
   const until = new Date(Date.now() + days * MS_DAY).toISOString();
   await sb
     .from("hall_snoozes")
-    .upsert({ entity_type: entityType, entity_id: entityId, until_at: until, reason, snoozed_by: snoozedBy }, {
-      onConflict: "entity_type,entity_id",
-    });
+    .upsert({
+      entity_type: entityType,
+      entity_id: entityId,
+      until_at: until,
+      snoozed_at: new Date().toISOString(),
+      reason,
+      snoozed_by: snoozedBy,
+    }, { onConflict: "entity_type,entity_id" });
+}
+
+/**
+ * L-011: dismiss = permanente. Uses a sentinel `until_at` ~9999 so the
+ * standard snooze reader still works (`until_at > now()`), but auto-lifts
+ * the moment a fresh signal arrives (see getPipelineState reader).
+ * Reason text is stored on the snooze row for audit only.
+ */
+export async function dismissEntityForever(
+  entityType: "organization" | "opportunity",
+  entityId: string,
+  reason: string | null,
+  by: string | null
+): Promise<void> {
+  const sb = getSupabaseServerClient();
+  const FOREVER = "9999-12-31T23:59:59Z";
+  await sb
+    .from("hall_snoozes")
+    .upsert({
+      entity_type: entityType,
+      entity_id: entityId,
+      until_at: FOREVER,
+      snoozed_at: new Date().toISOString(),
+      reason,
+      snoozed_by: by,
+    }, { onConflict: "entity_type,entity_id" });
 }
 
 export async function manualResolve(
@@ -652,9 +698,20 @@ export async function manualResolve(
     }
   }
 
-  if (closeUnderlying && reason === "drift" && entityType === "organization") {
-    // "Acknowledge — not pursuing" → snooze 30d as a soft dormancy signal.
-    await snoozeEntity(entityType, entityId, 30, "drift_acknowledged", resolvedBy);
+  // L-012 fix: the previous gate was `drift && organization` only, which
+  // meant Resolve on an opportunity (any reason) and Resolve on an org with
+  // reason ∈ {ball_with_them, ball_with_jose} closed the log but wrote
+  // ZERO suppression — the same row re-opened on next render. The user
+  // bug "I dismiss in Pipeline and it comes back" lives here.
+  //
+  // Now: any non-pre_meeting Resolve writes a forever snooze. The reader's
+  // auto-lift (lastSignal > snoozed_at) keeps this honest — if the
+  // counterpart re-engages with a fresh inbound, the row surfaces again
+  // because the signal IS new. pre_meeting Resolve ("Skip prep") stays
+  // unsnoozed: the next meeting with the same entity is a different event,
+  // not the same row to suppress.
+  if (closeUnderlying && reason !== "pre_meeting") {
+    await dismissEntityForever(entityType, entityId, `manual_${reason}`, resolvedBy);
   }
 
   return { closedLog: (closed?.length ?? 0) > 0, closedItems };


### PR DESCRIPTION
## Context

User reported: pressing dismiss buttons in the Hall (Inbox / Pipeline State / Ready-for-Jose / Suggested Time Blocks) hides items briefly, but they keep reappearing on next render.

Full audit ran (see commit body). Inbox was actually OK — the persistence works. The real culprits, all three matching the L-011 / L-012 / L-013 patterns documented in the failed commit `3d38a47` (reverted in the panic over the `null.replace` crash that we fixed in #22):

## Fixes

### 1. Pipeline State — `dismissEntityForever` + reader auto-lift (L-012)
- `manualResolve` gated suppression on `closeUnderlying && reason==='drift' && entityType==='organization'`. Opportunities (any reason) + orgs with `ball_with_jose` / `ball_with_them` / drift closed the log but wrote ZERO to `hall_snoozes`. Row came back next render.
- **New**: every non-`pre_meeting` Resolve writes a forever snooze (sentinel `until_at = 9999-12-31`). `pre_meeting` Skip stays unsnoozed (next meeting is a different event).
- **Reader auto-lift**: snooze is lifted only when a fresh signal (inbound email / transcript / opp signal) arrives AFTER `snoozed_at`. Real re-engagement isn't buried; stale items stay gone.

### 2. Suggested Time Blocks Dismiss (L-011)
- Reader had `dismissed_at > now - 24h` cutoff. Same fingerprint reappeared every day. **Drop the cutoff.** Snooze cutoffs unchanged.

### 3. Ready for Jose Dismiss (L-011 + L-013)
- Was pure-client localStorage with 24h TTL. Switch browser, clear cache, wait a day → all drafts back.
- The migration creating `hall_draft_dismissals` was already in prod from 2026-05-18 but the writer + reader code was reverted.
- **New**: `POST /api/agent-drafts/dismiss` writes `(draft_notion_id, user_id)` to `hall_draft_dismissals`. `getDismissedDraftIds(user.id)` filters server-side in `/admin/page.tsx`. Component still does optimistic local hide for instant feedback.

## Out of scope (audit found these too, but not user-blockers right now)
- CoS desk Done/Drop on project/evidence-source tasks — silent no-op branch (`ChiefOfStaffDesk.tsx:394-397`)
- `/api/hall/commitments/[id]` — deprecated route, no caller, safe to delete
- Push notification snooze — stub route, `push_snoozes` table exists but no writer/reader

## Test plan
- [ ] CI green
- [ ] After merge: open `/admin`, click "Acknowledge — not pursuing" on a Pipeline row → reload → row stays gone
- [ ] Dismiss a Suggested Time Block → wait or hard-reload → stays gone (until a new fingerprint surfaces)
- [ ] Dismiss a Ready-for-Jose draft → reload in different browser/incognito → stays gone for this user
- [ ] If a counterpart sends an email to a dismissed opp → row resurfaces (auto-lift works as designed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXQ52bGfpGSjV2njYCk7a)_