### PR TITLE
fix(tier2): broken Hall buttons (silent failures + invertido + doble-mount)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1313,13 +1313,12 @@ export default async function AdminPage({ searchParams }: { searchParams?: Promi
                 <CompetitiveIntelPanel rows={competitiveIntel} lastScanAt={competitiveLastScan} />
               </HallSection>
 
-              <HallSection
-                title="Inbox · "
-                flourish="needs attention"
-                meta={`${inboxData.items.length} VISIBLE · ${inboxData.total_scanned} TOTAL`}
-              >
-                <InboxTriage initialItems={inboxData.items} initialScanned={inboxData.total_scanned} />
-              </HallSection>
+              {/* InboxTriage is rendered in the Today tab above; duplicating
+                  it here mounted a second client component instance whose
+                  state (dismissed rows, optimistic hides) was independent
+                  from Today's, so user actions in Today didn't reflect here
+                  until full reload. The Signals tab keeps its real signals
+                  panels (Market + Competitive Intel) above. */}
 
               <HallSection title="Waiting on " flourish="others">
                 <Suspense fallback={<HallSkeleton lines={3} />}><HallAskQueue /></Suspense>

--- a/src/components/CandidateSection.tsx
+++ b/src/components/CandidateSection.tsx
@@ -65,11 +65,13 @@ export function CandidateSection({ candidates }: Props) {
   const [scanning, setScanning] = useState(false);
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [actionErr, setActionErr] = useState<{ id: string; msg: string } | null>(null);
 
   async function handleAction(candidateId: string, action: "promote" | "ignore") {
     setActing(candidateId);
+    setActionErr(null);
     try {
-      await fetch("/api/promote-candidate", {
+      const res = await fetch("/api/promote-candidate", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -78,10 +80,19 @@ export function CandidateSection({ candidates }: Props) {
           ...(action === "ignore" ? { reason: "Ignored via Hall review" } : {}),
         }),
       });
-      // Optimistic: remove from view immediately
+      // Surface server-side failures instead of pretending they succeeded.
+      // Optimistic hide was lying when the API returned 4xx/5xx — the row
+      // came back next render with no explanation.
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({} as { error?: string }));
+        setActionErr({ id: candidateId, msg: body?.error ?? `HTTP ${res.status}` });
+        return;
+      }
       setDismissed(prev => new Set(prev).add(candidateId));
-      router.refresh(); // re-fetch server data in background
-    } catch { /* silent */ } finally {
+      router.refresh();
+    } catch (e) {
+      setActionErr({ id: candidateId, msg: e instanceof Error ? e.message : String(e) });
+    } finally {
       setActing(null);
     }
   }
@@ -244,6 +255,11 @@ export function CandidateSection({ candidates }: Props) {
                   Notion →
                 </a>
               </div>
+              {actionErr?.id === c.id && (
+                <p className="text-[10px] text-red-500 mt-1">
+                  Acción falló: {actionErr.msg}
+                </p>
+              )}
             </div>
           </div>
         );

--- a/src/components/HallPipelineStateRow.tsx
+++ b/src/components/HallPipelineStateRow.tsx
@@ -26,12 +26,15 @@ const TREND_COLOR: Record<SerializedPipelineRow["trend"], string> = {
   cold:    "var(--hall-danger)",
 };
 
+type ApiResult<T = Record<string, unknown>> = { ok: true; body: T } | { ok: false; error: string };
+
 export function HallPipelineStateRow({ row }: { row: SerializedPipelineRow }) {
   const router = useRouter();
   const [busy, setBusy] = useState<"primary" | "resolve" | "snooze" | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
 
-  async function callApi(path: string, body: object): Promise<boolean> {
+  async function callApi<T = Record<string, unknown>>(path: string, body: object): Promise<ApiResult<T>> {
     setErr(null);
     try {
       const res = await fetch(path, {
@@ -39,50 +42,83 @@ export function HallPipelineStateRow({ row }: { row: SerializedPipelineRow }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
+      const j = await res.json().catch(() => ({}));
       if (!res.ok) {
-        const j = await res.json().catch(() => ({}));
-        setErr(j.error ?? `HTTP ${res.status}`);
-        return false;
+        const errorMsg = (j && typeof j === "object" && "error" in j) ? String(j.error) : `HTTP ${res.status}`;
+        setErr(errorMsg);
+        return { ok: false, error: errorMsg };
       }
-      return true;
+      return { ok: true, body: j as T };
     } catch (e) {
-      setErr(String(e));
-      return false;
+      const errorMsg = e instanceof Error ? e.message : String(e);
+      setErr(errorMsg);
+      return { ok: false, error: errorMsg };
     }
+  }
+
+  function flashToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3500);
   }
 
   async function onPrimary() {
     setBusy("primary");
-    const ok = await callApi("/api/pipeline-state/draft", {
+    const result = await callApi<{
+      ok?: boolean;
+      navigate?: boolean;
+      queued?: boolean;
+      logged?: boolean;
+      draftId?: string | null;
+      snoozedDays?: number;
+      note?: string;
+    }>("/api/pipeline-state/draft", {
       entityType: row.entityType,
       entityId:   row.entityId,
       action:     row.ctaPrimary.action,
       payload:    row.ctaPrimary.payload ?? {},
     });
     setBusy(null);
-    if (ok) router.refresh();
+    if (!result.ok) return;
+
+    const b = result.body;
+    // Branch by what the server actually did, not just "request succeeded":
+    //   navigate=true  → open_prep / open_review — take the user to row.url
+    //   queued=true    → draft skill ran — tell the user to check inbox
+    //   logged=true    → honest fallback — click was recorded + snoozed
+    if (b.navigate) {
+      if (row.url) {
+        window.open(row.url, "_blank", "noopener,noreferrer");
+      } else {
+        flashToast("No hay enlace asociado a esta fila.");
+      }
+    } else if (b.queued) {
+      flashToast("Borrador encolado. Revísalo en tu bandeja.");
+    } else if (b.logged) {
+      flashToast(`Anotado. Snooze ${b.snoozedDays ?? 1}d hasta que llegue señal nueva.`);
+    }
+    router.refresh();
   }
 
   async function onResolve() {
     setBusy("resolve");
-    const ok = await callApi("/api/pipeline-state/resolve", {
+    const result = await callApi("/api/pipeline-state/resolve", {
       entityType: row.entityType,
       entityId:   row.entityId,
       reason:     row.reason,
     });
     setBusy(null);
-    if (ok) router.refresh();
+    if (result.ok) router.refresh();
   }
 
   async function onSnooze(days: number) {
     setBusy("snooze");
-    const ok = await callApi("/api/pipeline-state/snooze", {
+    const result = await callApi("/api/pipeline-state/snooze", {
       entityType: row.entityType,
       entityId:   row.entityId,
       days,
     });
     setBusy(null);
-    if (ok) router.refresh();
+    if (result.ok) router.refresh();
   }
 
   return (
@@ -213,6 +249,11 @@ export function HallPipelineStateRow({ row }: { row: SerializedPipelineRow }) {
         {err && (
           <p className="text-[10px] ml-5" style={{ color: "var(--hall-danger)" }}>
             {err}
+          </p>
+        )}
+        {toast && (
+          <p className="text-[10px] ml-5" style={{ color: "var(--hall-muted-1)" }}>
+            {toast}
           </p>
         )}
       </div>

--- a/src/components/HallTimeAllocation.tsx
+++ b/src/components/HallTimeAllocation.tsx
@@ -132,10 +132,14 @@ export async function HallTimeAllocation() {
           .map(a => {
             const pct = totalHours > 0 ? (a.hours / totalHours) * 100 : 0;
             const target = a.bucket.target;
+            // L-005 fix: previously `far ? "OVER"` — when you have 0 hours
+            // against a target, the correct status is UNDER (you're below
+            // target), not OVER. The label was counter-factual and read as
+            // "Client 0%/20% — OVER" which made no sense.
             const far  = target > 0 && a.hours === 0;
             const near = target > 0 && pct > 0 && pct < target;
             const over = target > 0 && pct > target * 1.5;
-            const status = far ? "OVER" : near ? "UNDER" : over ? "OVER" : target > 0 ? "OK" : "";
+            const status = far ? "UNDER" : near ? "UNDER" : over ? "OVER" : target > 0 ? "OK" : "";
             const statusColor = far ? "var(--hall-danger)"
               : near ? "var(--hall-warn)"
               : over ? "var(--hall-danger)"

--- a/src/components/RadarSection.tsx
+++ b/src/components/RadarSection.tsx
@@ -28,18 +28,28 @@ const INTEREST_BADGE: Record<string, { label: string; cls: string }> = {
   interested: { label: "Interested", cls: "bg-[#c6f24a]/20 text-[#0a0a0a] border border-[#c6f24a]/40" },
 };
 
-async function patchInterest(loopId: string, founderInterest: string | null) {
-  await fetch("/api/cos-loops", {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ loopId, founderInterest }),
-  });
+async function patchInterest(loopId: string, founderInterest: string | null): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch("/api/cos-loops", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ loopId, founderInterest }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({} as { error?: string }));
+      return { ok: false, error: body?.error ?? `HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
 }
 
 export function RadarSection({ initialLoops }: { initialLoops: RadarLoop[] }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [optimistic, setOptimistic] = useState<Record<string, string | null>>({});
+  const [errs, setErrs] = useState<Record<string, string>>({});
 
   // Optimistic state:
   //   "dropped"    → remove from Radar immediately
@@ -50,8 +60,18 @@ export function RadarSection({ initialLoops }: { initialLoops: RadarLoop[] }) {
   });
 
   async function handleAction(loopId: string, founderInterest: string | null) {
+    setErrs(prev => { const n = { ...prev }; delete n[loopId]; return n; });
     setOptimistic(prev => ({ ...prev, [loopId]: founderInterest }));
-    await patchInterest(loopId, founderInterest);
+    const result = await patchInterest(loopId, founderInterest);
+    if (!result.ok) {
+      // Roll back optimistic state and surface the failure inline. Previous
+      // version silently kept the optimistic hide even on 4xx/5xx, so the
+      // user saw "success" but the row came back on next refresh with no
+      // explanation.
+      setOptimistic(prev => { const n = { ...prev }; delete n[loopId]; return n; });
+      setErrs(prev => ({ ...prev, [loopId]: result.error ?? "Failed" }));
+      return;
+    }
     startTransition(() => { router.refresh(); });
   }
 
@@ -134,6 +154,9 @@ export function RadarSection({ initialLoops }: { initialLoops: RadarLoop[] }) {
                   Drop
                 </button>
               </div>
+              {errs[loop.id] && (
+                <span className="text-[9px] text-red-500 ml-2 shrink-0">{errs[loop.id]}</span>
+              )}
             </div>
           );
         })}


### PR DESCRIPTION
## Tier 2 — botones rotos en el Hall

Five surfaces where "appears to work" hid actual no-ops or wrong behavior:

| # | Surface | Before | After |
|---|---|---|---|
| 1 | **Pipeline State Primary CTA** ("Draft check-in", "Open prep", "Open review") | Client only `router.refresh()`, ignored `{navigate, queued, logged}` body → silent no-op | Reads body, branches: `navigate` → opens row.url in new tab; `queued` / `logged` → inline toast |
| 2 | **CandidateSection** "Create Opportunity" / "Ignore" | `await fetch()` with no `res.ok` check → optimistic hide even on 4xx/5xx | Surfaces error inline, only hides on real success |
| 3 | **RadarSection** Watch / Interested / Drop | Same pattern | Rolls back optimistic state on failure, shows error inline |
| 4 | **HallTimeAllocation** status label | `far ? "OVER"` (0% vs 20% target labeled OVER — counter-factual) | "UNDER" with same danger color |
| 5 | **InboxTriage double-mount** | Mounted in Today AND Signals tabs; local state independent → dismisses in one tab invisible in the other | Removed Signals duplicate (Today keeps Inbox; Signals already has Market Signals + Competitive Intel) |

## Test plan
- [ ] CI green
- [ ] Pipeline State row primary button: open_prep variant opens the doc; draft-skill variant shows the toast
- [ ] Candidate "Ignore" with a forced 500 surfaces error instead of silent hide
- [ ] HallTimeAllocation row with 0% reads "UNDER", not "OVER"
- [ ] Dismiss an Inbox row in Today, switch to Signals — no longer see a different Inbox state (Inbox is now Today-only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXQ52bGfpGSjV2njYCk7a)_