### PR TITLE
fix(tier3): kill 999d sentinel in 6 sub-pages

### DIFF
--- a/src/app/admin/deal-flow/page.tsx
+++ b/src/app/admin/deal-flow/page.tsx
@@ -3,17 +3,23 @@ import { Sidebar } from "@/components/Sidebar";
 import { getProjectsOverview, getDecisionItems } from "@/lib/notion";
 import { requireAdmin } from "@/lib/require-admin";
 
-function daysSince(dateStr: string | null): number {
-  if (!dateStr) return 999;
+/** Days since `dateStr`, or null when there's no recorded activity. */
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
   return Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400000);
 }
 
-type WarmthKey = "hot" | "warm" | "cold";
+type WarmthKey = "hot" | "warm" | "cold" | "unknown";
 
-function warmth(days: number): { key: WarmthKey; label: string; dot: string; text: string } {
-  if (days < 7)  return { key: "hot",  label: "Hot",  dot: "var(--hall-danger)", text: "var(--hall-danger)" };
-  if (days <= 30) return { key: "warm", label: "Warm", dot: "var(--hall-warn)",  text: "var(--hall-warn)" };
-  return              { key: "cold", label: "Cold", dot: "var(--hall-info)",   text: "var(--hall-info)" };
+/** Renders Hot/Warm/Cold from days; null (no activity recorded) → Unknown.
+ *  Previously we returned 999 as a sentinel and then compared `days < 999`
+ *  at every site — leaked "999d" to the UI if a single comparator was
+ *  missed and forced "Cold" warmth on entities with literally no signal. */
+function warmth(days: number | null): { key: WarmthKey; label: string; dot: string; text: string } {
+  if (days === null) return { key: "unknown", label: "—", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+  if (days < 7)      return { key: "hot",     label: "Hot",  dot: "var(--hall-danger)", text: "var(--hall-danger)" };
+  if (days <= 30)    return { key: "warm",    label: "Warm", dot: "var(--hall-warn)",  text: "var(--hall-warn)" };
+  return                    { key: "cold",    label: "Cold", dot: "var(--hall-info)",   text: "var(--hall-info)" };
 }
 
 // Commercial pipeline stages in funnel order
@@ -331,10 +337,10 @@ export default async function DealFlowPage() {
                                 className="text-[10px] font-medium tabular-nums"
                                 style={{
                                   fontFamily: "var(--font-hall-mono)",
-                                  color: days > 30 ? "var(--hall-danger)" : "var(--hall-muted-2)",
+                                  color: (days !== null && days > 30) ? "var(--hall-danger)" : "var(--hall-muted-2)",
                                 }}
                               >
-                                {days < 999 ? `${days}d` : "—"}
+                                {days !== null ? `${days}d` : "—"}
                               </p>
                             ) : (
                               <span className="text-[12px]" style={{color: "var(--hall-muted-3)"}}>—</span>
@@ -343,7 +349,7 @@ export default async function DealFlowPage() {
 
                           {/* Warmth */}
                           <div className="flex items-center gap-1.5">
-                            {days < 999 ? (
+                            {days !== null ? (
                               <>
                                 <span
                                   className="shrink-0"

--- a/src/app/admin/garage-view/page.tsx
+++ b/src/app/admin/garage-view/page.tsx
@@ -3,17 +3,22 @@ import { Sidebar } from "@/components/Sidebar";
 import { getProjectsOverview } from "@/lib/notion";
 import { requireAdmin } from "@/lib/require-admin";
 
-function daysSince(dateStr: string | null): number {
-  if (!dateStr) return 999;
+/** Days since `dateStr`, or null when there's no recorded activity.
+ *  Previously returned 999 as a sentinel; passing that to warmthLabel
+ *  silently classified entities-with-no-signal as "Dormant" which is
+ *  semantically wrong (no data ≠ cold). */
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
   return Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400000);
 }
 
-function warmthLabel(days: number): { label: string; dot: string; text: string } {
-  if (days <= 3)  return { label: "Hot",     dot: "var(--hall-danger)", text: "var(--hall-danger)" };
-  if (days <= 10) return { label: "Warm",    dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
-  if (days <= 21) return { label: "Active",  dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
-  if (days <= 35) return { label: "Cold",    dot: "var(--hall-info)",   text: "var(--hall-info)" };
-  return              { label: "Dormant", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+function warmthLabel(days: number | null): { label: string; dot: string; text: string } {
+  if (days === null) return { label: "—",       dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+  if (days <= 3)     return { label: "Hot",     dot: "var(--hall-danger)", text: "var(--hall-danger)" };
+  if (days <= 10)    return { label: "Warm",    dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
+  if (days <= 21)    return { label: "Active",  dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
+  if (days <= 35)    return { label: "Cold",    dot: "var(--hall-info)",   text: "var(--hall-info)" };
+  return                    { label: "Dormant", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
 }
 
 const STAGE_STYLES: Record<string, { bg: string; color: string; border?: string }> = {

--- a/src/app/admin/garage/[id]/page.tsx
+++ b/src/app/admin/garage/[id]/page.tsx
@@ -19,14 +19,16 @@ import { GarageDetailClient } from "./GarageDetailClient";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
-function daysSince(dateStr: string | null): number {
-  if (!dateStr) return 999;
+/** Days since `dateStr`, or null when there's no recorded activity. */
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
   return Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400000);
 }
 
-function warmthLabel(days: number): { label: string; dot: string; text: string } {
-  if (days <= 3)  return { label: "Hot",     dot: "var(--hall-danger)",  text: "var(--hall-danger)"  };
-  if (days <= 10) return { label: "Warm",    dot: "var(--hall-warn)",    text: "var(--hall-warn)"    };
+function warmthLabel(days: number | null): { label: string; dot: string; text: string } {
+  if (days === null) return { label: "—",       dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+  if (days <= 3)     return { label: "Hot",     dot: "var(--hall-danger)",  text: "var(--hall-danger)"  };
+  if (days <= 10)    return { label: "Warm",    dot: "var(--hall-warn)",    text: "var(--hall-warn)"    };
   if (days <= 21) return { label: "Active",  dot: "var(--hall-warn)",    text: "var(--hall-warn)"    };
   if (days <= 35) return { label: "Cold",    dot: "var(--hall-info)",    text: "var(--hall-info)"    };
   return               { label: "Dormant", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };

--- a/src/app/admin/investors/page.tsx
+++ b/src/app/admin/investors/page.tsx
@@ -3,17 +3,19 @@ import { Sidebar } from "@/components/Sidebar";
 import { getAllPeople, getProjectsOverview, getDecisionItems } from "@/lib/notion";
 import { requireAdmin } from "@/lib/require-admin";
 
-function daysSince(dateStr: string | null): number {
-  if (!dateStr) return 999;
+/** Days since `dateStr`, or null when there's no recorded activity. */
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
   return Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400000);
 }
 
-function warmthLabel(days: number): { label: string; dot: string; text: string } {
-  if (days <= 3)  return { label: "Hot",     dot: "var(--hall-danger)", text: "var(--hall-danger)" };
-  if (days <= 14) return { label: "Warm",    dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
-  if (days <= 30) return { label: "Active",  dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
-  if (days <= 60) return { label: "Cold",    dot: "var(--hall-info)",   text: "var(--hall-info)" };
-  return              { label: "Dormant", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+function warmthLabel(days: number | null): { label: string; dot: string; text: string } {
+  if (days === null) return { label: "—",       dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+  if (days <= 3)     return { label: "Hot",     dot: "var(--hall-danger)", text: "var(--hall-danger)" };
+  if (days <= 14)    return { label: "Warm",    dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
+  if (days <= 30)    return { label: "Active",  dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
+  if (days <= 60)    return { label: "Cold",    dot: "var(--hall-info)",   text: "var(--hall-info)" };
+  return                    { label: "Dormant", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
 }
 
 const INVESTOR_ROLES = ["Investor", "Angel", "VC", "LP", "Fund", "Funder", "Backer", "Grant Funder", "Grant Maker", "Impact Investor"];

--- a/src/app/admin/os/page.tsx
+++ b/src/app/admin/os/page.tsx
@@ -36,15 +36,17 @@ const TYPE_ICON: Record<string, { icon: string; style: CSSProperties }> = {
   "Draft Review":               { icon: "▤", style: { color: "var(--hall-ink-0)",    background: "var(--hall-fill-soft)" } },
 };
 
-function daysSince(iso: string | null): number {
-  if (!iso) return 999;
+/** Days since `iso`, or null when there's no date. */
+function daysSince(iso: string | null): number | null {
+  if (!iso) return null;
   return Math.floor((Date.now() - new Date(iso).getTime()) / 86400000);
 }
 
 function DecisionCard({ d }: { d: DecisionItem }) {
   const needsExecute = d.requiresExecute && !d.executeApproved;
   const tCfg = TYPE_ICON[d.decisionType] ?? { icon: "·", style: { color: "var(--hall-muted-3)", background: "var(--hall-fill-soft)" } };
-  const overdue = d.dueDate && daysSince(d.dueDate) > 0;
+  const overdueDays = d.dueDate ? daysSince(d.dueDate) : null;
+  const overdue = overdueDays !== null && overdueDays > 0;
   return (
     <div
       className="px-6 py-4 flex items-start gap-4"
@@ -256,9 +258,11 @@ export default async function OSPage() {
   const reviewEvidenceRaw = allEvidence.filter(e => e.validationStatus === "Reviewed");
   // "Passing through" — only last 14 days. Older Reviewed items are archived by
   // the engine (validation-operator ARCHIVE tier) and don't belong in the queue.
-  const reviewEvidence    = reviewEvidenceRaw.filter(e =>
-    e.dateCaptured ? daysSince(e.dateCaptured) <= 14 : false,
-  );
+  const reviewEvidence    = reviewEvidenceRaw.filter(e => {
+    if (!e.dateCaptured) return false;
+    const d = daysSince(e.dateCaptured);
+    return d !== null && d <= 14;
+  });
   const validatedEvidence = allEvidence.filter(e => e.validationStatus === "Validated");
   const blockers          = allEvidence.filter(e => e.type === "Blocker" && e.validationStatus === "Validated");
 

--- a/src/app/admin/workrooms/page.tsx
+++ b/src/app/admin/workrooms/page.tsx
@@ -6,17 +6,19 @@ import { Sidebar } from "@/components/Sidebar";
 import { getWorkroomProjectsOverview } from "@/lib/notion-cached";
 import { requireAdmin } from "@/lib/require-admin";
 
-function daysSince(dateStr: string | null): number {
-  if (!dateStr) return 999;
+/** Days since `dateStr`, or null when there's no recorded activity. */
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
   return Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400000);
 }
 
-function warmthLabel(days: number): { label: string; dot: string; text: string } {
-  if (days <= 3)  return { label: "Hot",     dot: "var(--hall-danger)", text: "var(--hall-danger)" };
-  if (days <= 10) return { label: "Warm",    dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
-  if (days <= 21) return { label: "Active",  dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
-  if (days <= 35) return { label: "Cold",    dot: "var(--hall-info)",   text: "var(--hall-info)" };
-  return              { label: "Dormant", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+function warmthLabel(days: number | null): { label: string; dot: string; text: string } {
+  if (days === null) return { label: "—",       dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
+  if (days <= 3)     return { label: "Hot",     dot: "var(--hall-danger)", text: "var(--hall-danger)" };
+  if (days <= 10)    return { label: "Warm",    dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
+  if (days <= 21)    return { label: "Active",  dot: "var(--hall-warn)",   text: "var(--hall-warn)" };
+  if (days <= 35)    return { label: "Cold",    dot: "var(--hall-info)",   text: "var(--hall-info)" };
+  return                    { label: "Dormant", dot: "var(--hall-muted-3)", text: "var(--hall-muted-3)" };
 }
 
 const STAGE_STYLES: Record<string, { bg: string; color: string }> = {
@@ -52,7 +54,13 @@ export default async function WorkroomsPage() {
 
   const withBlockers   = activeClients.filter(p => p.blockerCount > 0);
   const needsUpdate    = activeClients.filter(p => p.updateNeeded);
-  const staleCount     = activeClients.filter(p => daysSince(p.lastUpdate) > 30).length;
+  // Stale = updated >30d ago. Projects with NO recorded last_update are
+  // not counted as stale here (no signal ≠ cold); the legacy sentinel
+  // 999 made them all inflate this count.
+  const staleCount     = activeClients.filter(p => {
+    const d = daysSince(p.lastUpdate);
+    return d !== null && d > 30;
+  }).length;
   const executionCount = activeClients.filter(p => p.stage === "Execution").length;
 
   const todayLabel = new Date().toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });


### PR DESCRIPTION
## Tier 3 — kill the `999d` sentinel in 6 sub-pages

Same family as the "9999d" / "99999d" leaks already fixed on the main Hall and Cold-relations widget.

Each sub-page had its own local `daysSince` returning 999 when the date was null, then piping that into a `warmthLabel` that classified the entity as Dormant/Cold — even when there's literally NO signal recorded (no data ≠ cold).

Files:
- `/admin/deal-flow`
- `/admin/garage-view`
- `/admin/garage/[id]`
- `/admin/investors`
- `/admin/workrooms`
- `/admin/os`

Pattern: `daysSince` returns `number|null`; `warmth*` accepts null and renders "—" muted.

**Additional fixes** (caught while touching these files):
- `/admin/workrooms` — `staleCount` filter used to count EVERY null-lastUpdate project as stale (because `999 > 30`). Now skips nulls.
- `/admin/os` — overdue check on `DecisionCard` and the 14-day review-evidence filter now null-guard explicitly.

## Test plan
- [ ] CI green
- [ ] None of `/admin/deal-flow`, `/admin/garage-view`, `/admin/garage/[id]`, `/admin/investors`, `/admin/workrooms`, `/admin/os` show "999d" anywhere
- [ ] Workrooms stale count drops to a sane number
- [ ] No-signal entities show "—" warmth instead of "Dormant"


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXQ52bGfpGSjV2njYCk7a)_