### PR TITLE
fix(tier4): zero post-cutoff Notion writes + sanitise top-6 cron err-leaks

### DIFF
--- a/scripts/check-notion-cutoff.sh
+++ b/scripts/check-notion-cutoff.sh
@@ -32,16 +32,19 @@ PATTERN='await\s+notion\.(pages\.(create|update)|databases\.update|blocks\.child
 
 count_active() {
   local ref="$1"
+  # `|| true` keeps pipefail from blowing up the script when there are 0
+  # matches (the desired end state at cutoff): grep exits 1 on no matches,
+  # which under `set -o pipefail` was killing the count and exiting 1.
   if [ -z "$ref" ]; then
-    grep -rEh "$PATTERN" src/app src/lib src/components 2>/dev/null \
-      | grep -vE '^\s*//' \
-      | grep -vE 'notion-cutoff-(2026-06-02|exempt)' \
+    { grep -rEh "$PATTERN" src/app src/lib src/components 2>/dev/null || true; } \
+      | { grep -vE '^\s*//' || true; } \
+      | { grep -vE 'notion-cutoff-(2026-06-02|exempt)' || true; } \
       | wc -l \
       | tr -d ' '
   else
-    git grep -hE "$PATTERN" "$ref" -- src/app src/lib src/components 2>/dev/null \
-      | grep -vE '^\s*//' \
-      | grep -vE 'notion-cutoff-(2026-06-02|exempt)' \
+    { git grep -hE "$PATTERN" "$ref" -- src/app src/lib src/components 2>/dev/null || true; } \
+      | { grep -vE '^\s*//' || true; } \
+      | { grep -vE 'notion-cutoff-(2026-06-02|exempt)' || true; } \
       | wc -l \
       | tr -d ' '
   fi

--- a/scripts/err-leak-baseline.txt
+++ b/scripts/err-leak-baseline.txt
@@ -11,9 +11,6 @@ src/app/api/contact-topics/synthesize/route.ts
 src/app/api/cos-loops/route.ts
 src/app/api/create-candidate/route.ts
 src/app/api/create-project-folders/route.ts
-src/app/api/cron/observe-calendar/route.ts
-src/app/api/cron/refresh-org-topics/route.ts
-src/app/api/cron/run-inbox-classify/route.ts
 src/app/api/edit-pitch/route.ts
 src/app/api/extract-conversation-evidence/route.ts
 src/app/api/extract-meeting-evidence/route.ts
@@ -24,12 +21,10 @@ src/app/api/garage-ingest/route.ts
 src/app/api/grants-data/route.ts
 src/app/api/hall-contacts/route.ts
 src/app/api/hall-manual-triggers-status/route.ts
-src/app/api/hall-organizations/sync-notion/route.ts
 src/app/api/hall/ask-queue/route.ts
 src/app/api/hall/nudge-draft/route.ts
 src/app/api/inbox-ignore/route.ts
 src/app/api/inbox-triage/route.ts
-src/app/api/ingest-gmail/route.ts
 src/app/api/ingest-library/digest/execute/route.ts
 src/app/api/ingest-library/digest/route.ts
 src/app/api/ingest-meetings/route.ts
@@ -53,7 +48,6 @@ src/app/api/run-skill/linkedin-post/route.ts
 src/app/api/save-pitch-batch/route.ts
 src/app/api/scan-opportunity-candidates/route.ts
 src/app/api/seed-grant-sources/route.ts
-src/app/api/send-draft/route.ts
 src/app/api/setup-all-drives/route.ts
 src/app/api/sync-evidence/route.ts
 src/app/api/sync-loops/route.ts

--- a/src/app/api/cron/observe-calendar/route.ts
+++ b/src/app/api/cron/observe-calendar/route.ts
@@ -16,6 +16,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { syncCalendarDelta } from "@/lib/calendar-sync";
 import { withRoutineLog } from "@/lib/routine-log";
+import { apiError } from "@/lib/api-error";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -43,10 +44,7 @@ async function handle(req: NextRequest) {
     const result = await syncCalendarDelta();
     return NextResponse.json(result, { status: result.ok ? 200 : 502 });
   } catch (err) {
-    return NextResponse.json(
-      { ok: false, error: "unhandled", detail: err instanceof Error ? err.message : String(err) },
-      { status: 500 },
-    );
+    return apiError(err, { route: "[/api/cron/observe-calendar]" });
   }
 }
 

--- a/src/app/api/cron/refresh-org-topics/route.ts
+++ b/src/app/api/cron/refresh-org-topics/route.ts
@@ -168,7 +168,11 @@ Output JSON only: {"topics":[{"label":"..."},{"label":"..."},{"label":"..."}]}. 
       const m = text.match(/\{[\s\S]*\}/);
       if (m) parsed = JSON.parse(m[0]);
     } catch (e) {
-      results.push({ org_notion_id: orgId, topic_count: 0, ok: false, error: String(e) });
+      // Log full error server-side, surface a sanitised label to the
+      // caller. err.message from JSON.parse on LLM output can include
+      // payload fragments — not for cron-secret consumers.
+      console.error("[/api/cron/refresh-org-topics] parse failed for org", orgId, e);
+      results.push({ org_notion_id: orgId, topic_count: 0, ok: false, error: "parse_failed" });
       continue;
     }
 

--- a/src/app/api/cron/run-inbox-classify/route.ts
+++ b/src/app/api/cron/run-inbox-classify/route.ts
@@ -45,7 +45,9 @@ async function handle(req: Request) {
     .limit(BATCH);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    // Don't echo Postgres error.message (column names / schema hints).
+    console.error("[/api/cron/run-inbox-classify] supabase read failed:", error);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
   }
 
   const rows = (items ?? []) as InboxItem[];
@@ -55,6 +57,8 @@ async function handle(req: Request) {
 
   let processed = 0;
   let skipped = 0;
+  // We expose per-item OUTCOMES (sanitised) — never raw exception text.
+  // The full error goes to the server log keyed by item id.
   const errors: Array<{ id: string; error: string }> = [];
 
   for (const item of rows) {
@@ -64,11 +68,13 @@ async function handle(req: Request) {
         processed++;
       } else {
         skipped++;
+        // r.error is a controlled string set by the classifier — keep it.
         errors.push({ id: item.id, error: r.error || "unknown" });
       }
     } catch (e) {
       skipped++;
-      errors.push({ id: item.id, error: String(e) });
+      console.error("[/api/cron/run-inbox-classify] classify threw for item", item.id, e);
+      errors.push({ id: item.id, error: "classifier_exception" });
     }
   }
 

--- a/src/app/api/hall-organizations/sync-notion/route.ts
+++ b/src/app/api/hall-organizations/sync-notion/route.ts
@@ -101,8 +101,10 @@ export async function POST(req: NextRequest) {
       }
     }
   } catch (err) {
+    // Notion search errors can include workspace IDs / token error names.
+    console.error("[/api/hall-organizations/sync-notion] org search failed:", err);
     return NextResponse.json(
-      { error: "organizations search failed", detail: err instanceof Error ? err.message : String(err) },
+      { error: "organizations search failed" },
       { status: 502 },
     );
   }
@@ -144,8 +146,9 @@ export async function POST(req: NextRequest) {
       matchedId = (created.notion_id as string | null) ?? (created.id as string);
       action = "created";
     } catch (err) {
+      console.error("[/api/hall-organizations/sync-notion] org insert failed:", err);
       return NextResponse.json(
-        { error: "organizations insert failed", detail: err instanceof Error ? err.message : String(err) },
+        { error: "organizations insert failed" },
         { status: 502 },
       );
     }

--- a/src/app/api/ingest-gmail/route.ts
+++ b/src/app/api/ingest-gmail/route.ts
@@ -150,7 +150,9 @@ async function _POST(req: NextRequest) {
     });
     threadIds = (listRes.data.threads ?? []).map(t => t.id!).filter(Boolean);
   } catch (err) {
-    return NextResponse.json({ ok: false, error: String(err) }, { status: 500 });
+    // Gmail OAuth errors can include refresh-token paths in the message.
+    console.error("[/api/ingest-gmail] threads.list failed:", err);
+    return NextResponse.json({ ok: false, error: "Internal error" }, { status: 500 });
   }
 
   // Resolve the OAuth owner's email so we can exclude self from attendee

--- a/src/app/api/seed-grant-sources/route.ts
+++ b/src/app/api/seed-grant-sources/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
-import { notion, DB } from "@/lib/notion";
 import { adminGuardApi } from "@/lib/require-admin";
+import { getSupabaseServerClient } from "@/lib/supabase-server";
 
-// One-shot seed for Grant Sources [OS v2]
+// One-shot seed for the grant_sources Supabase table.
 // POST /api/seed-grant-sources
-// Protected by secret header to prevent accidental re-runs
+//
+// Migrated 2026-06-09 from Notion (`notion.pages.create` against
+// `DB.grantSources`) to Supabase, per the 2026-06-02 Notion deprecation
+// cutoff. The previous version violated the freeze rule by adding fresh
+// Notion writes; this version is the canonical writer for grant_sources.
+// Source-list payload identical to the prior seed.
+
+export const dynamic = "force-dynamic";
 
 const SOURCES: {
   name: string;
@@ -121,32 +128,50 @@ const SOURCES: {
 ];
 
 export async function POST(req: NextRequest) {
+  void req;
   const guard = await adminGuardApi();
   if (guard) return guard;
 
-  const results: { name: string; id: string }[] = [];
+  const sb = getSupabaseServerClient();
+  const results: { name: string; id: string | null }[] = [];
   const errors: { name: string; error: string }[] = [];
 
   for (const src of SOURCES) {
     try {
-      const page = await notion.pages.create({
-        parent: { database_id: DB.grantSources },
-        properties: {
-          "Source Name": { title: [{ text: { content: src.name } }] },
-          "URL":         { url: src.url },
-          "Type":        { select: { name: src.type } },
-          "Geography":   { multi_select: src.geo.map(g => ({ name: g })) },
-          "Themes":      { multi_select: src.themes.map(t => ({ name: t })) },
-          "Active":      { checkbox: true },
-        },
-      });
-      results.push({ name: src.name, id: page.id });
+      // Upsert on funder_url so re-runs don't duplicate. Type is stored in
+      // notes (no enum column in the canonical schema); themes go to the
+      // array column; geo joined to the text column. payload preserves the
+      // original shape for any consumer that wants it back.
+      const { data, error } = await sb
+        .from("grant_sources")
+        .upsert({
+          title:       src.name,
+          funder_name: src.name,
+          funder_url:  src.url,
+          status:      "Active",
+          themes:      src.themes,
+          geography:   src.geo.join(", "),
+          notes:       `type:${src.type}`,
+          payload:     { type: src.type, geo: src.geo, themes: src.themes },
+        }, { onConflict: "funder_url" })
+        .select("id")
+        .single();
+      if (error) {
+        errors.push({ name: src.name, error: error.message });
+        continue;
+      }
+      results.push({ name: src.name, id: data?.id ?? null });
     } catch (e) {
-      errors.push({ name: src.name, error: String(e) });
+      errors.push({ name: src.name, error: e instanceof Error ? e.message : "unknown" });
     }
   }
 
-  return NextResponse.json(
-    { ok: true, seeded: results.length, errorCount: errors.length, results, errors }
-  );
+  return NextResponse.json({
+    ok:          errors.length === 0,
+    seeded:      results.length,
+    errorCount:  errors.length,
+    results,
+    errors,
+    destination: "supabase:grant_sources",
+  });
 }

--- a/src/app/api/send-draft/route.ts
+++ b/src/app/api/send-draft/route.ts
@@ -170,9 +170,12 @@ export async function POST(req: NextRequest) {
       subject,
     });
   } catch (err) {
+    // Gmail send errors can include account hints / refresh-token failure
+    // strings — log server-side, surface a generic message to the caller.
+    console.error("[/api/send-draft] gmail send failed:", err);
     return NextResponse.json({
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: "Internal error",
     }, { status: 500 });
   }
 }

--- a/src/lib/notion/knowledge.ts
+++ b/src/lib/notion/knowledge.ts
@@ -1,4 +1,5 @@
 import { notion, DB, prop, text, select, multiSelect } from "./core";
+import { getSupabaseServerClient } from "@/lib/supabase-server";
 
 // ─── Knowledge Assets ─────────────────────────────────────────────────────────
 
@@ -36,6 +37,20 @@ export async function getKnowledgeAssets(): Promise<KnowledgeAsset[]> {
 
 // ─── Library ingest ───────────────────────────────────────────────────────────
 
+/**
+ * Library ingest writer for knowledge assets.
+ *
+ * Migrated 2026-06-09 from Notion (`notion.pages.create` against
+ * `DB.knowledge`) to Supabase, per the 2026-06-02 deprecation cutoff.
+ * Returns the canonical knowledge_assets.id (uuid) — call sites that
+ * stored the string verbatim already treat it as opaque.
+ *
+ * Body composition: keeps the same author intent (summary + bulleted
+ * key points + source-note footer) but renders to markdown stored in
+ * `body_md`, so the editor in /admin/knowledge-assets/[id] can edit it
+ * inline. Source URL + storage path are preserved in `payload` for any
+ * downstream consumer that needs the raw context.
+ */
 export async function createKnowledgeAssetDraft(opts: {
   title: string;
   summary: string;
@@ -48,49 +63,44 @@ export async function createKnowledgeAssetDraft(opts: {
 }): Promise<string> {
   const { title, summary, keyPoints, assetType, tags, sourceNote, sourceFileUrl, storagePath } = opts;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const page = await notion.pages.create({
-    parent: { database_id: DB.knowledge },
-    properties: {
-      "Asset Name":        { title: [{ text: { content: title } }] },
-      "Asset Type":        { select: { name: assetType } },
-      "Domain / Theme":    { multi_select: tags.slice(0, 5).map(t => ({ name: t })) },
-      "Status":            { select: { name: "Draft" } },
-      "Portal Visibility": { select: { name: "admin-only" } },
-      ...(sourceFileUrl ? { "Source File URL": { url: sourceFileUrl } } : {}),
-    } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    children: [
-      {
-        object: "block",
-        type: "paragraph",
-        paragraph: { rich_text: [{ type: "text", text: { content: summary } }] },
-      },
-      ...(keyPoints.length > 0 ? [
-        {
-          object: "block" as const,
-          type: "bulleted_list_item" as const,
-          bulleted_list_item: { rich_text: [{ type: "text" as const, text: { content: "Key points:" } }] },
-        },
-        ...keyPoints.slice(0, 8).map(pt => ({
-          object: "block" as const,
-          type: "bulleted_list_item" as const,
-          bulleted_list_item: { rich_text: [{ type: "text" as const, text: { content: pt } }] },
-        })),
-      ] : []),
-      ...(sourceNote || storagePath ? [{
-        object: "block" as const,
-        type: "paragraph" as const,
-        paragraph: {
-          rich_text: [{ type: "text" as const, text: {
-            content: [
-              sourceNote ? `📎 Source: ${sourceNote}` : null,
-              storagePath ? `🗂 storage: ${storagePath}` : null,
-            ].filter(Boolean).join("  ·  "),
-          }}],
-        },
-      }] : []),
-    ],
-  });
+  const bodyParts: string[] = [summary];
+  if (keyPoints.length > 0) {
+    bodyParts.push("");
+    bodyParts.push("**Key points**");
+    for (const pt of keyPoints.slice(0, 8)) bodyParts.push(`- ${pt}`);
+  }
+  if (sourceNote || storagePath) {
+    bodyParts.push("");
+    bodyParts.push([
+      sourceNote ? `📎 Source: ${sourceNote}` : null,
+      storagePath ? `🗂 storage: ${storagePath}` : null,
+    ].filter(Boolean).join("  ·  "));
+  }
+  const bodyMd = bodyParts.join("\n");
 
-  return page.id;
+  const sb = getSupabaseServerClient();
+  const { data, error } = await sb
+    .from("knowledge_assets")
+    .insert({
+      title,
+      asset_type: assetType,
+      status:     "Draft",
+      summary,
+      body_md:    bodyMd,
+      payload:    {
+        tags: tags.slice(0, 5),
+        portal_visibility: "admin-only",
+        source_file_url: sourceFileUrl ?? null,
+        source_note: sourceNote ?? null,
+        storage_path: storagePath ?? null,
+        key_points: keyPoints,
+      },
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    throw new Error(`createKnowledgeAssetDraft: ${error?.message ?? "insert returned no row"}`);
+  }
+  return data.id as string;
 }


### PR DESCRIPTION
## Tier 4 — backend hygiene

Three backend-hygiene fixes addressing the API-routes audit.

### 1. Notion deprecation cutoff — 2 of 2 active writes migrated to Supabase
- **`/api/seed-grant-sources`** — rewritten to UPSERT into `grant_sources` (Supabase) on `funder_url` (idempotent). Source list unchanged.
- **`createKnowledgeAssetDraft`** in `src/lib/notion/knowledge.ts` — INSERTs into `knowledge_assets` (Supabase). Body composition: summary + key points + source footer is rendered to markdown stored in `body_md`; metadata that doesn't fit columns goes into `payload` jsonb. Returns a uuid string (callers treat it opaquely).

`bash scripts/check-notion-cutoff.sh` → `Active call sites went down by 2.`

Also fixed a `set -o pipefail` bug in that guard script — with 0 matches, the `grep -vE` pipeline returned exit 1 and broke. Now each grep is wrapped `|| true`.

### 2. Err-leak hygiene — top 6 cron/external-secret routes
Highest-exposure subset of the err-leak baseline. Each switched to `console.error` server-side + stable public message:
- `cron/observe-calendar` (Google Calendar errors)
- `cron/run-inbox-classify` (Postgres + classifier errors)
- `cron/refresh-org-topics` (LLM payload fragments)
- `ingest-gmail` (Gmail OAuth refresh-token paths)
- `send-draft` (Gmail account hints)
- `hall-organizations/sync-notion` (Notion workspace + token errors)

`bash scripts/check-no-err-leak.sh` → `Baseline=57 | Current=57 | Fixed=0` (all 6 gone from both).

## Out of scope (audit findings to handle separately)
- `loop_actions` table: 7 writers, 0 readers — needs a product call.
- 3 Garage tables (`cap_table_entries` / `financial_snapshots` / `valuations`) — written by `/api/garage-ingest`, never read.
- `console.error` → `debug_log` migration across 50 API routes — mechanical but large.

## Test plan
- [ ] CI green
- [ ] `/api/seed-grant-sources` POST creates rows in `grant_sources` (Supabase)
- [ ] Library ingest creates `knowledge_assets` rows; `/admin/knowledge-assets/[id]` can edit them
- [ ] 6 cron routes return generic "Internal error" instead of raw stack on failure


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXQ52bGfpGSjV2njYCk7a)_