### PR TITLE
fix(tier5): lime-reserved + outbox count honesty + no "—d" leak

### DIFF
--- a/src/app/admin/health/page.tsx
+++ b/src/app/admin/health/page.tsx
@@ -487,7 +487,10 @@ export default async function HealthPage() {
                           className="text-[10px] font-bold uppercase tracking-widest mt-0.5"
                           style={{ fontFamily: "var(--font-hall-mono)", color: "var(--hall-danger)" }}
                         >
-                          Stale · {daysSince(bestActivity(p)) ?? "—"}d since last activity
+                          {(() => {
+                            const d = daysSince(bestActivity(p));
+                            return d !== null ? `Stale · ${d}d since last activity` : "Stale · no activity recorded";
+                          })()}
                         </p>
                       </div>
                       <StatusBadge value={p.stage} />

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1602,7 +1602,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Promi
                           <span className="shrink-0" style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--hall-danger)" }} />
                           <span className="flex-1 min-w-0 truncate text-[12px] font-semibold" style={{ color: "var(--hall-ink-0)" }}>{p.name}</span>
                           <span className="font-semibold shrink-0" style={{ fontFamily: "var(--font-hall-mono)", fontSize: 10, color: "var(--hall-danger)" }}>
-                            {daysSince(bestActivity(p)) ?? "—"}d
+                            {(() => { const d = daysSince(bestActivity(p)); return d !== null ? `${d}d` : "—"; })()}
                           </span>
                         </Link>
                       </li>

--- a/src/components/AgentQueueSection.tsx
+++ b/src/components/AgentQueueSection.tsx
@@ -178,9 +178,13 @@ export function AgentQueueSection({ drafts }: { drafts: AgentDraft[] }) {
 
   if (visible.length === 0) return null;
 
+  const RENDER_CAP = 6;
+  const overflow = Math.max(0, visible.length - RENDER_CAP);
+
   return (
-    <div className="grid grid-cols-3 gap-3">
-      {visible.slice(0, 6).map((draft) => {
+    <div className="space-y-2">
+      <div className="grid grid-cols-3 gap-3">
+      {visible.slice(0, RENDER_CAP).map((draft) => {
         const icon        = DRAFT_TYPE_ICON[draft.draftType] ?? "·";
         const isLinkedIn  = draft.draftType === "LinkedIn Post";
         const isEmail     = EMAIL_TYPES.has(draft.draftType);
@@ -588,6 +592,19 @@ export function AgentQueueSection({ drafts }: { drafts: AgentDraft[] }) {
           </div>
         );
       })}
+      </div>
+      {/* Audit fix: the Outbox section header used to show `count={agentDrafts.length}`
+          while only 6 cards rendered — "8 drafts" with 6 visible was misleading.
+          Surfacing the overflow inline keeps the count honest. */}
+      {overflow > 0 && (
+        <a
+          href="/admin/agents"
+          className="block text-center text-[10px] font-bold uppercase tracking-widest py-2"
+          style={{ color: "var(--hall-muted-2)", fontFamily: "var(--font-hall-mono)" }}
+        >
+          +{overflow} more in queue →
+        </a>
+      )}
     </div>
   );
 }

--- a/src/components/HallOrgsWidgets.tsx
+++ b/src/components/HallOrgsWidgets.tsx
@@ -83,15 +83,19 @@ export async function HallOrgsColdRelations() {
 
 // ─── Class mix ──────────────────────────────────────────────────────────────
 
+// Lime (#c6f24a) is reserved per PORTAL_DESIGN for Focus-of-day, LIVE
+// pulse, and the brand logo only — never buckets/badges. Client uses the
+// ink corporate black; VIP uses ink with an outline to distinguish from
+// Team while staying outside the reserved palette.
 const MIX_CLASSES = ["Client", "Partner", "Portfolio", "Investor", "Funder", "Team", "VIP"] as const;
 const MIX_COLOR: Record<typeof MIX_CLASSES[number], string> = {
-  Client:    "bg-[#c6f24a]",
+  Client:    "bg-[#0a0a0a]",
   Partner:   "bg-[#7dd3fc]",
   Portfolio: "bg-[#fbbf24]",
   Investor:  "bg-[#a78bfa]",
   Funder:    "bg-[#f472b6]",
-  Team:      "bg-[#0a0a0a]",
-  VIP:       "bg-[#c6f24a]",
+  Team:      "bg-[#52525b]",
+  VIP:       "bg-[#1f1f24] ring-1 ring-[#52525b]",
 };
 
 export async function HallOrgsClassMix() {

--- a/src/components/HallTimeAllocation.tsx
+++ b/src/components/HallTimeAllocation.tsx
@@ -13,14 +13,16 @@ import { getSelfEmails } from "@/lib/hall-self";
  * Jose sets soft targets by CLASS below — red-flagged if below target.
  */
 
+// Lime (#c6f24a) is reserved per PORTAL_DESIGN — Client/VIP recoloured to
+// stay outside the brand palette while keeping the buckets distinct.
 const BUCKETS = [
-  { key: "Client",       label: "Client",       color: "bg-[#c6f24a]", target: 20 },
+  { key: "Client",       label: "Client",       color: "bg-[#0a0a0a]", target: 20 },
   { key: "Investor",     label: "Investor",     color: "bg-[#a78bfa]", target: 10 },
   { key: "Funder",       label: "Funder",       color: "bg-[#f472b6]", target: 5  },
   { key: "Portfolio",    label: "Portfolio",    color: "bg-[#fbbf24]", target: 20 },
   { key: "Partner",      label: "Partner",      color: "bg-[#7dd3fc]", target: 15 },
-  { key: "VIP",          label: "VIP",          color: "bg-[#c6f24a]", target: 0  },
-  { key: "Team",         label: "Team",         color: "bg-[#0a0a0a]", target: 10 },
+  { key: "VIP",          label: "VIP",          color: "bg-[#1f1f24]", target: 0  },
+  { key: "Team",         label: "Team",         color: "bg-[#52525b]", target: 10 },
   { key: "Vendor",       label: "Vendor",       color: "bg-[#9ca3af]", target: 0  },
   { key: "External",     label: "External",     color: "bg-[#cbd5e1]", target: 0  },
   { key: "Personal",     label: "Personal",     color: "bg-amber-300", target: 0  },

--- a/src/components/RadarSection.tsx
+++ b/src/components/RadarSection.tsx
@@ -23,9 +23,11 @@ const LOOP_TYPE_LABEL: Record<string, string> = {
   commitment: "Commitment",
 };
 
+// Lime reserved per PORTAL_DESIGN — "Interested" status uses ink-on-paper
+// instead of the brand lime to keep lime exclusive to Focus / LIVE.
 const INTEREST_BADGE: Record<string, { label: string; cls: string }> = {
-  watching:   { label: "Watching", cls: "bg-amber-50 text-amber-600 border border-amber-200" },
-  interested: { label: "Interested", cls: "bg-[#c6f24a]/20 text-[#0a0a0a] border border-[#c6f24a]/40" },
+  watching:   { label: "Watching",   cls: "bg-amber-50 text-amber-600 border border-amber-200" },
+  interested: { label: "Interested", cls: "bg-[#0a0a0a]/5 text-[#0a0a0a] border border-[#0a0a0a]/15" },
 };
 
 async function patchInterest(loopId: string, founderInterest: string | null): Promise<{ ok: boolean; error?: string }> {
@@ -95,7 +97,7 @@ export function RadarSection({ initialLoops }: { initialLoops: RadarLoop[] }) {
           const movingToCoS = interest === "interested" && optimistic[loop.id] === "interested";
 
           return (
-            <div key={loop.id} className={`flex items-center gap-3 px-5 py-3.5 transition-colors ${movingToCoS ? "bg-[#c6f24a]/10" : ""}`}>
+            <div key={loop.id} className={`flex items-center gap-3 px-5 py-3.5 transition-colors ${movingToCoS ? "bg-[#0a0a0a]/5" : ""}`}>
               {/* Type badge */}
               <span className="text-[8px] font-bold uppercase tracking-widest text-[#0a0a0a]/30 bg-[#f4f4ef] px-2 py-0.5 rounded-full shrink-0">
                 {typeLabel}
@@ -120,7 +122,7 @@ export function RadarSection({ initialLoops }: { initialLoops: RadarLoop[] }) {
 
               {/* Interest state badge */}
               {movingToCoS ? (
-                <span className="text-[8px] font-bold px-2 py-0.5 rounded-full shrink-0 bg-[#c6f24a] text-[#0a0a0a]">
+                <span className="text-[8px] font-bold px-2 py-0.5 rounded-full shrink-0 bg-[#0a0a0a] text-white">
                   → CoS
                 </span>
               ) : badge ? (
@@ -142,7 +144,7 @@ export function RadarSection({ initialLoops }: { initialLoops: RadarLoop[] }) {
                 {interest !== "interested" && (
                   <button
                     onClick={() => handleAction(loop.id, "interested")}
-                    className="text-[9px] font-bold px-2.5 py-1 rounded-lg bg-[#c6f24a] text-[#0a0a0a] hover:bg-[#b8e54a] transition-colors"
+                    className="text-[9px] font-bold px-2.5 py-1 rounded-lg bg-[#0a0a0a] text-white hover:bg-[#1f1f24] transition-colors"
                   >
                     Interested
                   </button>

--- a/src/components/ReadyForJoseSection.tsx
+++ b/src/components/ReadyForJoseSection.tsx
@@ -138,8 +138,11 @@ export function ReadyForJoseSection({
                       className="text-[8px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full"
                       style={{
                         fontFamily: "var(--font-hall-mono)",
-                        background: "#c8f55a",
+                        // Lime reserved (PORTAL_DESIGN). Status chip on a
+                        // draft uses neutral ink-soft, not the brand colour.
+                        background: "var(--hall-fill-soft)",
                         color: "var(--hall-ink-0)",
+                        border: "1px solid var(--hall-line-soft)",
                       }}
                     >
                       Draft

--- a/src/components/TriggerBriefingButton.tsx
+++ b/src/components/TriggerBriefingButton.tsx
@@ -24,11 +24,18 @@ export function TriggerBriefingButton() {
     }
   }
 
+  // Reset to idle so the user can retry without a full reload.
+  if (state === "done") {
+    setTimeout(() => setState("idle"), 4000);
+  }
+
   return (
     <button
       onClick={trigger}
       disabled={state === "loading" || state === "done"}
-      className="shrink-0 text-[11px] font-bold px-3 py-1.5 rounded-lg bg-[#c6f24a] text-[#0a0a0a] hover:bg-[#b8e54a] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+      // hall-btn-primary = solid ink-0 per PORTAL_DESIGN — lime is reserved
+      // for Focus / LIVE / brand only.
+      className="hall-btn-primary shrink-0 text-[11px] px-3 py-1.5 disabled:opacity-40 disabled:cursor-not-allowed"
     >
       {state === "loading" ? "Generating…"
         : state === "done"    ? "Done — actualizando…"


### PR DESCRIPTION
## Tier 5 — UX/diseño nits

Five PORTAL_DESIGN / UX nits from the audit:

### 1. Lime-reserved violations
Per PORTAL_DESIGN: lime is for Focus-of-day + LIVE pulse + brand logo only.
- `HallOrgsClassMix`: Client + VIP buckets → ink shades
- `HallTimeAllocation`: Client + VIP buckets → ink shades
- `RadarSection`: "Interested" badge / moving-to-CoS row / → CoS chip / action button → ink-on-paper (action button uses solid ink-0 like `hall-btn-primary`)
- `TriggerBriefingButton`: switched to `hall-btn-primary` + 4s auto-reset from "Done" → idle
- `ReadyForJoseSection`: "Draft" chip → `--hall-fill-soft` + border

PrepBriefModal lime uses left intact (pulse-loading reads as LIVE-pulse; dark accent is brand highlight within a focused-reading surface).

### 2. Outbox badge mismatch
Section rendered `agentDrafts.slice(0, 6)` but header showed `count={agentDrafts.length}`. With 8 drafts users saw "8" but 6 cards. Now shows `+N more in queue →` linking to `/admin/agents`.

### 3. "—d" suffix leak in stale projects
`${daysSince(...) ?? "—"}d` rendered literally "—d". Both sites (`admin/page.tsx`, `admin/health`) now branch explicitly.

### Out of scope
- "Open decisions" → list-only navigation: no per-decision detail route exists, building one is product work.
- Mixed-locale Pipeline State strings: deliberate bilingual UI (repo convention, owner-set).

## Test plan
- [ ] CI green
- [ ] Cold-relations + Time Allocation no longer show brand lime in Client/VIP buckets
- [ ] Radar "Interested" reads as ink, not lime
- [ ] "Generate briefing" returns to idle after 4s and uses ink-primary
- [ ] Outbox with >6 drafts shows "+N more in queue →"
- [ ] Stale projects never show "—d"


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXQ52bGfpGSjV2njYCk7a)_