### PR TITLE
fix(observability): wire 6 hot-spot routes to debug_log

### DIFF
--- a/src/app/api/cron/observe-calendar/route.ts
+++ b/src/app/api/cron/observe-calendar/route.ts
@@ -17,6 +17,7 @@ import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { syncCalendarDelta } from "@/lib/calendar-sync";
 import { withRoutineLog } from "@/lib/routine-log";
 import { apiError } from "@/lib/api-error";
+import { logServerError } from "@/lib/debug-log";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -44,6 +45,8 @@ async function handle(req: NextRequest) {
     const result = await syncCalendarDelta();
     return NextResponse.json(result, { status: result.ok ? 200 : 502 });
   } catch (err) {
+    // Capture full stack to debug_log (Vercel logs truncate to ~240 chars).
+    await logServerError("api/cron/observe-calendar", err);
     return apiError(err, { route: "[/api/cron/observe-calendar]" });
   }
 }

--- a/src/app/api/cron/refresh-org-topics/route.ts
+++ b/src/app/api/cron/refresh-org-topics/route.ts
@@ -16,6 +16,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
+import { logServerError } from "@/lib/debug-log";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -168,10 +169,8 @@ Output JSON only: {"topics":[{"label":"..."},{"label":"..."},{"label":"..."}]}. 
       const m = text.match(/\{[\s\S]*\}/);
       if (m) parsed = JSON.parse(m[0]);
     } catch (e) {
-      // Log full error server-side, surface a sanitised label to the
-      // caller. err.message from JSON.parse on LLM output can include
-      // payload fragments — not for cron-secret consumers.
-      console.error("[/api/cron/refresh-org-topics] parse failed for org", orgId, e);
+      // Full stack to debug_log; per-org context for SQL debugging.
+      await logServerError("api/cron/refresh-org-topics", e, { orgId, phase: "parse_llm_output" });
       results.push({ org_notion_id: orgId, topic_count: 0, ok: false, error: "parse_failed" });
       continue;
     }

--- a/src/app/api/cron/run-inbox-classify/route.ts
+++ b/src/app/api/cron/run-inbox-classify/route.ts
@@ -15,6 +15,7 @@
 import { NextResponse } from "next/server";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { classifyInboxItem } from "@/lib/inbox-classifier";
+import { logServerError } from "@/lib/debug-log";
 import type { InboxItem } from "@/lib/inbox";
 
 export const runtime = "nodejs";
@@ -45,8 +46,8 @@ async function handle(req: Request) {
     .limit(BATCH);
 
   if (error) {
-    // Don't echo Postgres error.message (column names / schema hints).
-    console.error("[/api/cron/run-inbox-classify] supabase read failed:", error);
+    // Full stack to debug_log (Vercel logs truncate to ~240 chars).
+    await logServerError("api/cron/run-inbox-classify", error, { phase: "supabase_read" });
     return NextResponse.json({ error: "Internal error" }, { status: 500 });
   }
 
@@ -73,7 +74,7 @@ async function handle(req: Request) {
       }
     } catch (e) {
       skipped++;
-      console.error("[/api/cron/run-inbox-classify] classify threw for item", item.id, e);
+      await logServerError("api/cron/run-inbox-classify", e, { phase: "classify", itemId: item.id });
       errors.push({ id: item.id, error: "classifier_exception" });
     }
   }

--- a/src/app/api/hall-organizations/sync-notion/route.ts
+++ b/src/app/api/hall-organizations/sync-notion/route.ts
@@ -30,6 +30,7 @@ import { NextRequest, NextResponse } from "next/server";
 // const ORGS_DB = "bef1bb86ab2b4cd280b6b33f9034b96c";
 import { adminGuardApi } from "@/lib/require-admin";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
+import { logServerError } from "@/lib/debug-log";
 
 export const dynamic = "force-dynamic";
 
@@ -102,7 +103,7 @@ export async function POST(req: NextRequest) {
     }
   } catch (err) {
     // Notion search errors can include workspace IDs / token error names.
-    console.error("[/api/hall-organizations/sync-notion] org search failed:", err);
+    await logServerError("api/hall-organizations/sync-notion", err, { phase: "org_search" });
     return NextResponse.json(
       { error: "organizations search failed" },
       { status: 502 },
@@ -146,7 +147,7 @@ export async function POST(req: NextRequest) {
       matchedId = (created.notion_id as string | null) ?? (created.id as string);
       action = "created";
     } catch (err) {
-      console.error("[/api/hall-organizations/sync-notion] org insert failed:", err);
+      await logServerError("api/hall-organizations/sync-notion", err, { phase: "org_insert" });
       return NextResponse.json(
         { error: "organizations insert failed" },
         { status: 502 },

--- a/src/app/api/ingest-gmail/route.ts
+++ b/src/app/api/ingest-gmail/route.ts
@@ -23,6 +23,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { withRoutineLog } from "@/lib/routine-log";
 import { observeGmailThread } from "@/lib/hall-contact-observers";
+import { logServerError } from "@/lib/debug-log";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 
 /** Parse "Name <email@domain.com>" or raw email → lowercased email. */
@@ -150,8 +151,9 @@ async function _POST(req: NextRequest) {
     });
     threadIds = (listRes.data.threads ?? []).map(t => t.id!).filter(Boolean);
   } catch (err) {
-    // Gmail OAuth errors can include refresh-token paths in the message.
-    console.error("[/api/ingest-gmail] threads.list failed:", err);
+    // Gmail OAuth errors can include refresh-token paths — log the full
+    // stack to debug_log and return a stable public message.
+    await logServerError("api/ingest-gmail", err, { phase: "threads_list" });
     return NextResponse.json({ ok: false, error: "Internal error" }, { status: 500 });
   }
 

--- a/src/app/api/send-draft/route.ts
+++ b/src/app/api/send-draft/route.ts
@@ -21,6 +21,7 @@ import { google } from "googleapis";
 import { adminGuardApi } from "@/lib/require-admin";
 import { notion, DB } from "@/lib/notion";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
+import { logServerError } from "@/lib/debug-log";
 
 // ─── Gmail auth ───────────────────────────────────────────────────────────────
 
@@ -170,9 +171,9 @@ export async function POST(req: NextRequest) {
       subject,
     });
   } catch (err) {
-    // Gmail send errors can include account hints / refresh-token failure
-    // strings — log server-side, surface a generic message to the caller.
-    console.error("[/api/send-draft] gmail send failed:", err);
+    // Gmail send errors carry account hints / refresh-token paths — full
+    // stack to debug_log, generic message to the caller.
+    await logServerError("api/send-draft", err, { phase: "gmail_send" });
     return NextResponse.json({
       ok: false,
       error: "Internal error",


### PR DESCRIPTION
## Wire 6 hot-spot routes to debug_log

After the Notion-deprecation + err-leak sweeps, the 6 highest-traffic routes already had `console.error("[/api/X] msg:", err)` calls server-side. Vercel function logs truncate at ~240 chars — which is exactly what bit us in the 2026-05-18 `/admin` crash (the unhelpful redacted message made the bug invisible for weeks).

Migrated each `console.error` to `logServerError(...)` from `src/lib/debug-log.ts`, which persists the full stack + metadata to `public.debug_log`.

Full visibility from SQL:
```sql
SELECT source, message, stack, occurred_at FROM debug_log
WHERE source LIKE 'api/%' ORDER BY occurred_at DESC LIMIT 20;
```

Routes wired:
- `api/cron/observe-calendar`
- `api/cron/run-inbox-classify` (2 sites: supabase read, classify exception)
- `api/cron/refresh-org-topics` (LLM parse failure)
- `api/ingest-gmail` (Gmail threads.list)
- `api/send-draft` (Gmail send)
- `api/hall-organizations/sync-notion` (org search + insert)

## Scope
Only these 6 cron/external-secret routes. The remaining ~130 `console.error` sites across other API routes are deliberately NOT migrated — they're informational (not crash-debug), and `debug_log` has limited retention. Helper additions ad-hoc when a specific route earns its weight.

## Test plan
- [ ] CI green
- [ ] Trigger any of the 6 routes with a forced error → row appears in `debug_log` with `source LIKE 'api/%'`


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXQ52bGfpGSjV2njYCk7a)_