### PR TITLE
fix(agenda): render Today's agenda times in Hall prefs timezone, not server UTC

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1168,7 +1168,7 @@ export default async function AdminPage({ searchParams }: { searchParams?: Promi
               {/* ── Today's agenda — next meeting rich + rest compact ────── */}
               <HallSection title="Today's " flourish="agenda">
                 <Suspense fallback={<HallSkeleton lines={6} />}>
-                  <SafeServerSection name="HallTodayAgenda" render={() => HallTodayAgenda()} />
+                  <SafeServerSection name="HallTodayAgenda" render={() => HallTodayAgenda({ userEmail: adminUser.primaryEmailAddress?.emailAddress ?? "" })} />
                 </Suspense>
               </HallSection>
 

--- a/src/components/HallTodayAgenda.tsx
+++ b/src/components/HallTodayAgenda.tsx
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { getSelfEmails } from "@/lib/hall-self";
 import { getContactsByEmails } from "@/lib/contacts";
+import { getHallPreferences } from "@/lib/hall-preferences";
 
 type CalRow = {
   event_id: string;
@@ -31,6 +32,12 @@ type CompactMeeting = {
   attendeeNames: string[];
   htmlLink: string | null;
 };
+
+// Calendar-date key in the user's timezone (en-CA → "2026-06-10"). Server runs
+// in UTC, so date comparisons and labels must never use the process timezone.
+function dayKey(d: Date, tz: string): string {
+  return d.toLocaleDateString("en-CA", { timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit" });
+}
 
 function formatAway(startMs: number): string {
   const diff = startMs - Date.now();
@@ -81,9 +88,11 @@ async function generateTalkingPoints(
   }
 }
 
-export async function HallTodayAgenda() {
+export async function HallTodayAgenda({ userEmail }: { userEmail?: string } = {}) {
   const sb = getSupabaseServerClient();
   const selfSet = await getSelfEmails();
+  const prefs = await getHallPreferences(userEmail ?? "");
+  const tz = prefs.timezone;
 
   const now = new Date();
   const windowEnd = new Date(now);
@@ -104,9 +113,9 @@ export async function HallTodayAgenda() {
 
   const rows = allRows;
 
-  // Show date label when the first meeting is not today
-  const todayStr = now.toDateString();
-  const isFallback = rows.length > 0 && new Date(rows[0].event_start).toDateString() !== todayStr;
+  // Show date label when the first meeting is not today (in the user's timezone)
+  const todayStr = dayKey(now, tz);
+  const isFallback = rows.length > 0 && dayKey(new Date(rows[0].event_start), tz) !== todayStr;
 
   if (rows.length === 0) {
     return (
@@ -161,7 +170,7 @@ export async function HallTodayAgenda() {
     title:      cleanTitle(nextRow.event_title, nextAttendees),
     startMs:    nextStartMs,
     startLocal: new Date(nextRow.event_start).toLocaleString("en-GB", {
-      weekday: "short", hour: "2-digit", minute: "2-digit", day: "numeric", month: "short",
+      timeZone: tz, weekday: "short", hour: "2-digit", minute: "2-digit", day: "numeric", month: "short",
     }),
     attendees:  nextAttendees,
     lastTouch,
@@ -181,7 +190,7 @@ export async function HallTodayAgenda() {
       eventId:       r.event_id,
       title:         r.event_title,
       startMs,
-      timeLabel:     new Date(r.event_start).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" }),
+      timeLabel:     new Date(r.event_start).toLocaleTimeString("en-GB", { timeZone: tz, hour: "2-digit", minute: "2-digit" }),
       attendeeCount: others.length,
       attendeeNames: names.slice(0, 3),
       htmlLink:      r.html_link ?? null,
@@ -198,7 +207,7 @@ export async function HallTodayAgenda() {
           className="text-[8.5px] font-bold uppercase tracking-widest mb-2"
           style={{ color: "var(--hall-muted-3)", fontFamily: "var(--font-hall-mono)" }}
         >
-          Next · {new Date(nextRow.event_start).toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" })}
+          Next · {new Date(nextRow.event_start).toLocaleDateString("en-GB", { timeZone: tz, weekday: "short", day: "numeric", month: "short" })}
         </p>
       )}
       <div
@@ -288,7 +297,7 @@ export async function HallTodayAgenda() {
             </p>
             <p className="text-[11px] leading-snug" style={{ color: "var(--hall-muted-2)" }}>
               <span className="font-semibold" style={{ color: "var(--hall-ink-3)" }}>{next.lastTouch.kind}</span>
-              <span> · {next.lastTouch.at.slice(0, 10)} · </span>
+              <span> · {dayKey(new Date(next.lastTouch.at), tz)} · </span>
               <span className="line-clamp-1">{next.lastTouch.title}</span>
             </p>
           </div>
@@ -321,7 +330,7 @@ export async function HallTodayAgenda() {
         const groups: { dateLabel: string; meetings: CompactMeeting[] }[] = [];
         for (const m of rest) {
           const d = new Date(m.startMs);
-          const label = d.toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" });
+          const label = d.toLocaleDateString("en-GB", { timeZone: tz, weekday: "short", day: "numeric", month: "short" });
           const last = groups[groups.length - 1];
           if (last && last.dateLabel === label) last.meetings.push(m);
           else groups.push({ dateLabel: label, meetings: [m] });


### PR DESCRIPTION
## Problem

The "Today's agenda" widget on `/admin` rendered meeting times in **UTC** instead of the Hall preferences timezone. Observed in production 2026-06-10: "PAS check-in" showed `Wed 10 Jun, 14:00 - in 5h` at 10:29 London time — the event is at 15:00 London (14:00 UTC), so the printed hour was the server (UTC) hour. The Suggested Time Blocks cards on the same page already show London time correctly via `prefs.timezone`.

## Root cause

Every absolute-time formatter in `HallTodayAgenda.tsx` (`toLocaleString` / `toLocaleTimeString` / `toLocaleDateString`) omitted the `timeZone` option, so it used the process timezone — UTC on Vercel. Relative "in Xh" labels are epoch-based and were already correct.

## Fix

- `HallTodayAgenda` now accepts `userEmail`, resolves `getHallPreferences(email).timezone` (Europe/London for josemanuelmoller@gmail.com), and passes `timeZone` to every formatter — same approach as `time-block-candidates.ts`.
- `/admin/page.tsx` passes `adminUser.primaryEmailAddress` into the component.
- Fixed all five tz-sensitive spots: next-meeting `startLocal`, compact row `timeLabel`, day-group headers, the "Next ·" fallback date eyebrow, and the last-touch date.
- The "is today" check (drives the fallback eyebrow) now compares calendar dates in the user's timezone via a `dayKey` helper instead of server-TZ `toDateString()`.

## Verification

- `tsc --noEmit` clean for the changed files (pre-existing unrelated conflict markers in `src/lib/notion/knowledge.ts` are not part of this PR).
- Production verification at portal.wearecommonhouse.com/admin after deploy: PAS-type events must show the London hour (15:00, consistent with the "in Xh" label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
