### PR TITLE
feat(hall): Por cerrar pipeline strip + won/lost loop

### DIFF
--- a/src/app/api/opportunity-outcome/route.ts
+++ b/src/app/api/opportunity-outcome/route.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/opportunity-outcome
+ *
+ * Resolves a pipeline opportunity from the Hall's "Por cerrar" strip.
+ *
+ * Body: { id: string (opportunities.id uuid), outcome: "won" | "lost", amount?: number, currency?: string }
+ *
+ * - "won"  → opportunities.status = 'Won' + inserts a revenue_events row at
+ *            stage 'sold' (source 'hall', external_ref `opp:{id}`) so the
+ *            commitment counts against the quarter target immediately. When
+ *            the real Xero invoice arrives, the nightly sync supersedes the
+ *            manual sold row (see src/lib/xero-sync.ts) — no double counting.
+ * - "lost" → opportunities.status = 'Lost'. Row keeps its history; it simply
+ *            leaves the pipeline.
+ *
+ * Idempotent: the revenue event upserts on (source, external_ref), so a retry
+ * after a half-failure cannot duplicate the sold amount.
+ *
+ * Auth: adminGuardApi() — authenticated admin session required.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { adminGuardApi } from "@/lib/require-admin";
+import { getSupabaseServerClient } from "@/lib/supabase-server";
+
+export async function POST(req: NextRequest) {
+  const guard = await adminGuardApi();
+  if (guard) return guard;
+
+  let body: { id?: string; outcome?: string; amount?: number; currency?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { id, outcome } = body;
+  if (!id || (outcome !== "won" && outcome !== "lost")) {
+    return NextResponse.json({ error: "Body must be { id, outcome: 'won' | 'lost' }" }, { status: 400 });
+  }
+
+  const sb = getSupabaseServerClient();
+
+  const { data: opp, error: oppErr } = await sb
+    .from("opportunities")
+    .select("id, title, org_name, org_notion_id, value_estimate, status")
+    .eq("id", id)
+    .maybeSingle();
+  if (oppErr) return NextResponse.json({ error: oppErr.message }, { status: 500 });
+  if (!opp) return NextResponse.json({ error: "Opportunity not found" }, { status: 404 });
+
+  if (outcome === "lost") {
+    const { error } = await sb
+      .from("opportunities")
+      .update({ status: "Lost", is_active: false, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ ok: true, outcome: "lost" });
+  }
+
+  // won — the amount must be a real number; value_estimate is the default but
+  // the caller may override (e.g. final negotiated figure).
+  const amount = Number(body.amount ?? opp.value_estimate ?? 0);
+  if (!isFinite(amount) || amount <= 0) {
+    return NextResponse.json(
+      { error: "won requires a positive amount (value_estimate is empty — pass `amount`)" },
+      { status: 400 }
+    );
+  }
+  const currency = (body.currency ?? "USD").toUpperCase();
+
+  // Resolve organization uuid for the Xero reconciliation match (best-effort).
+  let organizationId: string | null = null;
+  if (opp.org_notion_id) {
+    const { data: org } = await sb
+      .from("organizations")
+      .select("id")
+      .eq("notion_id", opp.org_notion_id)
+      .maybeSingle();
+    organizationId = (org?.id as string | undefined) ?? null;
+  }
+  if (!organizationId && opp.org_name) {
+    const { data: org } = await sb
+      .from("organizations")
+      .select("id")
+      .ilike("name", opp.org_name)
+      .maybeSingle();
+    organizationId = (org?.id as string | undefined) ?? null;
+  }
+
+  const now = new Date();
+  const { error: revErr } = await sb.from("revenue_events").upsert(
+    {
+      source: "hall",
+      external_ref: `opp:${id}`,
+      stage: "sold",
+      amount,
+      currency,
+      opportunity_id: id,
+      organization_id: organizationId,
+      year: now.getUTCFullYear(),
+      quarter: Math.floor(now.getUTCMonth() / 3) + 1,
+      notes: `Hall · ${opp.org_name ?? opp.title}`,
+      updated_at: now.toISOString(),
+    },
+    { onConflict: "source,external_ref" }
+  );
+  if (revErr) return NextResponse.json({ error: `revenue event: ${revErr.message}` }, { status: 500 });
+
+  const { error: updErr } = await sb
+    .from("opportunities")
+    .update({ status: "Won", updated_at: now.toISOString() })
+    .eq("id", id);
+  if (updErr) {
+    // Revenue row exists but the status didn't move — surface it so the UI can retry.
+    return NextResponse.json(
+      { error: `revenue event created but status update failed: ${updErr.message}` },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ ok: true, outcome: "won", amount, currency });
+}

--- a/src/app/api/plan/compute-kpi/route.ts
+++ b/src/app/api/plan/compute-kpi/route.ts
@@ -111,7 +111,7 @@ type MetricParams = Record<string, string | number | undefined>;
 
 async function handleRevenueSum(db: SupabaseClient, p: MetricParams): Promise<number> {
   const stage = (p.stage as string) ?? "paid";
-  let q = db.from("revenue_events").select("amount, paid_amount, stage").eq("stage", stage);
+  let q = db.from("revenue_events").select("amount, paid_amount, stage").eq("stage", stage).is("superseded_at", null);
   if (p.year !== undefined) q = q.eq("year", p.year);
   if (p.quarter !== undefined) q = q.eq("quarter", p.quarter);
   const { data, error } = await q;

--- a/src/components/HallOppFreshnessRadar.tsx
+++ b/src/components/HallOppFreshnessRadar.tsx
@@ -24,7 +24,7 @@ async function loadColdOpps(): Promise<ColdOpp[]> {
     .select("notion_id, title, org_name, review_url, opportunity_type, status, follow_up_status, priority, value_estimate, next_meeting_at, updated_at")
     .eq("is_active", true)
     .eq("is_archived", false)
-    .in("status", ["New", "Qualifying", "Active"])
+    .in("status", ["New", "Qualifying", "Active", "Proposal Sent"])
     .not("opportunity_type", "eq", "Grant")
     .limit(120);
 

--- a/src/components/HallPipelineActions.tsx
+++ b/src/components/HallPipelineActions.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * HallPipelineActions — the ✓/✗ pair on each "Por cerrar" row of the Hall
+ * Revenue card.
+ *
+ * Won  → POST /api/opportunity-outcome {outcome:'won'} (amount defaults to
+ *        value_estimate; if the opp has none, asks for the final figure).
+ *        The row leaves the pipeline and the amount appears as "vendido" in
+ *        the card's progress line.
+ * Lost → same endpoint with {outcome:'lost'} after an explicit confirm.
+ *
+ * The list and the card totals are server-rendered on /admin, so a successful
+ * mutation triggers router.refresh() (soft re-render; client state survives).
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Props = {
+  id: string;
+  title: string;
+  /** value_estimate if present — used as the default won amount */
+  amount: number | null;
+};
+
+export function HallPipelineActions({ id, title, amount }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<"won" | "lost" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function resolve(outcome: "won" | "lost") {
+    if (busy) return;
+    setError(null);
+
+    let finalAmount: number | undefined;
+    if (outcome === "won") {
+      const raw = window.prompt(
+        `Monto final de "${title}" (USD)`,
+        amount && amount > 0 ? String(amount) : ""
+      );
+      if (raw === null) return; // cancelled
+      finalAmount = Number(raw.replace(/[,$\s]/g, ""));
+      if (!isFinite(finalAmount) || finalAmount <= 0) {
+        setError("Monto inválido");
+        return;
+      }
+    } else if (!window.confirm(`¿Marcar "${title}" como perdida?`)) {
+      return;
+    }
+
+    setBusy(outcome);
+    try {
+      const res = await fetch("/api/opportunity-outcome", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, outcome, ...(finalAmount ? { amount: finalAmount } : {}) }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setError(json.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const btnStyle: React.CSSProperties = {
+    fontFamily: "var(--font-hall-mono)",
+    fontSize: 8.5,
+    letterSpacing: "0.06em",
+    lineHeight: 1,
+    padding: "3px 6px",
+    borderRadius: 4,
+    border: "1px solid var(--hall-line-soft)",
+    background: "transparent",
+    cursor: busy ? "wait" : "pointer",
+  };
+
+  return (
+    <span className="shrink-0 inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => resolve("won")}
+        disabled={busy !== null}
+        title="Ganada — pasa a vendido en el card"
+        className="uppercase font-bold hover:underline"
+        style={{ ...btnStyle, color: "var(--hall-ok)" }}
+      >
+        {busy === "won" ? "…" : "✓ Ganada"}
+      </button>
+      <button
+        type="button"
+        onClick={() => resolve("lost")}
+        disabled={busy !== null}
+        title="Perdida — sale del pipeline, queda el histórico"
+        className="uppercase font-bold hover:underline"
+        style={{ ...btnStyle, color: "var(--hall-muted-2)" }}
+      >
+        {busy === "lost" ? "…" : "✗"}
+      </button>
+      {error && (
+        <span className="text-[9px]" style={{ color: "var(--hall-warn)" }} title={error}>
+          error
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/HallRevenueCard.tsx
+++ b/src/components/HallRevenueCard.tsx
@@ -15,6 +15,7 @@
 import Link from "next/link";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { getHallConfig } from "@/lib/hall-config";
+import { HallPipelineActions } from "@/components/HallPipelineActions";
 
 type RevRow = {
   stage: string;
@@ -25,6 +26,16 @@ type RevRow = {
   invoice_number: string | null;
   notes: string | null;
   quarter: number | null;
+};
+
+type PipeRow = {
+  id: string;
+  title: string;
+  org_name: string | null;
+  status: string;
+  value_estimate: number | string | null;
+  expected_close_date: string | null;
+  probability: string | null;
 };
 
 const CCY_SYMBOL: Record<string, string> = { USD: "$", GBP: "£", EUR: "€" };
@@ -76,18 +87,31 @@ export async function HallRevenueCard() {
   const quarter = Math.floor(now.getUTCMonth() / 3) + 1;
 
   const sb = getSupabaseServerClient();
-  const [ratesRes, eventsRes, targetRes] = await Promise.all([
+  const [ratesRes, eventsRes, targetRes, pipeRes] = await Promise.all([
     getUsdRates(),
     sb.from("revenue_events")
       .select("stage, amount, currency, due_date, invoice_date, invoice_number, notes, quarter")
-      .eq("year", year),
+      .eq("year", year)
+      .is("superseded_at", null),
     sb.from("strategic_objectives")
       .select("target_value")
       .eq("objective_type", "revenue")
       .eq("year", year)
       .eq("quarter", quarter)
       .maybeSingle(),
+    // Pipeline "Por cerrar": proposal out the door, or an active deal with a
+    // real number attached. Everything else lives in /admin/opportunities.
+    sb.from("opportunities")
+      .select("id, title, org_name, status, value_estimate, expected_close_date, probability")
+      .in("status", ["Proposal Sent", "Active"])
+      .eq("is_legacy", false)
+      .eq("is_archived", false)
+      .order("expected_close_date", { ascending: true, nullsFirst: false }),
   ]);
+
+  const pipeline = ((pipeRes.data ?? []) as PipeRow[]).filter(
+    p => p.status === "Proposal Sent" || Number(p.value_estimate ?? 0) > 0
+  );
 
   const rates = ratesRes;
   const yearRows = (eventsRes.data ?? []) as RevRow[];
@@ -127,7 +151,7 @@ export async function HallRevenueCard() {
     .map(([c, n]) => `${c} ${n.toLocaleString("en-US")}`)
     .join(" + ");
 
-  if (rows.length === 0 && target === 0) {
+  if (rows.length === 0 && target === 0 && pipeline.length === 0) {
     return (
       <p className="text-[11px]" style={{ color: "var(--hall-muted-3)" }}>
         Sin datos de revenue este trimestre — el sync de Xero corre cada madrugada.
@@ -202,6 +226,57 @@ export async function HallRevenueCard() {
                 >
                   {stage.label}
                 </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Por cerrar — propuestas enviadas y deals activos con monto. ✓ Ganada
+          crea el revenue_event 'sold' (suma al % de arriba); ✗ Perdida lo
+          saca del pipeline dejando el histórico. */}
+      {pipeline.length > 0 && (
+        <div className="mt-1.5 flex flex-col">
+          <p
+            className="uppercase tracking-[0.08em] font-bold mb-1"
+            style={{ fontFamily: "var(--font-hall-mono)", fontSize: 8.5, color: "var(--hall-muted-3)" }}
+          >
+            Por cerrar
+          </p>
+          {pipeline.map(p => {
+            const isProposal = p.status === "Proposal Sent";
+            const amount = Number(p.value_estimate ?? 0);
+            const meta = p.expected_close_date
+              ? `cierre ${p.expected_close_date.slice(5, 10)}`
+              : isProposal
+              ? "en espera"
+              : "por proponer";
+            return (
+              <div
+                key={p.id}
+                className="flex items-baseline gap-2 py-1"
+                style={{ borderTop: "1px solid var(--hall-line-soft)" }}
+              >
+                <span className="flex-1 min-w-0 truncate text-[10.5px]" style={{ color: "var(--hall-ink-2)" }}>
+                  {p.org_name ?? p.title}
+                  <span className="ml-1.5" style={{ fontFamily: "var(--font-hall-mono)", fontSize: 8.5, color: "var(--hall-muted-3)" }}>
+                    {meta}
+                  </span>
+                </span>
+                <span className="shrink-0 text-[10.5px] font-semibold" style={{ color: "var(--hall-ink-0)" }}>
+                  {amount > 0 ? fmtUsd(amount) : "—"}
+                </span>
+                <span
+                  className="shrink-0 uppercase tracking-[0.06em] font-bold"
+                  style={{
+                    fontFamily: "var(--font-hall-mono)",
+                    fontSize: 8,
+                    color: isProposal ? "var(--hall-warn)" : "var(--hall-muted-2)",
+                  }}
+                >
+                  {isProposal ? "propuesta" : "activa"}
+                </span>
+                <HallPipelineActions id={p.id} title={p.org_name ?? p.title} amount={amount > 0 ? amount : null} />
               </div>
             );
           })}

--- a/src/lib/pipeline-state.ts
+++ b/src/lib/pipeline-state.ts
@@ -187,7 +187,7 @@ export async function getPipelineState(): Promise<PipelineStateResult> {
       )
       .eq("is_active", true)
       .eq("is_archived", false)
-      .in("status", ["New", "Qualifying", "Active"])
+      .in("status", ["New", "Qualifying", "Active", "Proposal Sent"])
       .neq("opportunity_type", "Grant"),
   ]);
 

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -66,7 +66,8 @@ export async function getRevenueEventsForYear(year: number): Promise<RevenueEven
   const { data, error } = await supabaseAdmin()
     .from("revenue_events")
     .select("*")
-    .eq("year", year);
+    .eq("year", year)
+    .is("superseded_at", null);
   if (error) throw new Error(`getRevenueEventsForYear: ${error.message}`);
   return (data ?? []) as RevenueEvent[];
 }

--- a/src/lib/xero-sync.ts
+++ b/src/lib/xero-sync.ts
@@ -41,6 +41,8 @@ export type XeroSyncResult = {
   upserted: number;
   skipped: number;
   linked_orgs: number;
+  /** hall 'sold' placeholders replaced by a real invoice this run */
+  superseded: number;
   tenant: string | null;
   errors: string[];
 };
@@ -122,7 +124,7 @@ async function fetchAccRecInvoices(
 
 export async function syncXeroRevenue(): Promise<XeroSyncResult> {
   const errors: string[] = [];
-  const empty = { fetched: 0, upserted: 0, skipped: 0, linked_orgs: 0, tenant: null };
+  const empty = { fetched: 0, upserted: 0, skipped: 0, linked_orgs: 0, superseded: 0, tenant: null };
 
   const access = await getXeroAccess();
   if (!access.ok) {
@@ -218,6 +220,38 @@ export async function syncXeroRevenue(): Promise<XeroSyncResult> {
     else upserted = rows.length;
   }
 
+  // Reconciliation: a "won" placeholder from the Hall (source='hall', stage
+  // 'sold') counts against the target only until the real invoice exists.
+  // When an invoiced/paid Xero row for the same organization lands, supersede
+  // the placeholder so the card and KPIs don't double-count. Date guard: only
+  // invoices dated on/after the placeholder was created can supersede it — an
+  // old phase-1 invoice re-syncing must not eat a new phase-2 commitment.
+  let superseded = 0;
+  if (upserted > 0) {
+    const invoiceRows = rows.filter(
+      r => r.organization_id && (r.stage === "invoiced" || r.stage === "paid") && r.invoice_date
+    );
+    for (const inv of invoiceRows) {
+      const { data: hits, error: supErr } = await db
+        .from("revenue_events")
+        .update({ superseded_at: nowIso, superseded_by: String(inv.external_ref), updated_at: nowIso })
+        .eq("source", "hall")
+        .eq("stage", "sold")
+        .is("superseded_at", null)
+        .eq("organization_id", inv.organization_id as string)
+        .lte("created_at", `${inv.invoice_date}T23:59:59Z`)
+        .select("id");
+      if (supErr) {
+        errors.push(`supersede after ${inv.invoice_number ?? inv.external_ref}: ${supErr.message}`);
+      } else if (hits && hits.length > 0) {
+        superseded += hits.length;
+        console.warn(
+          `[xero-sync] superseded ${hits.length} hall sold event(s) via invoice ${inv.invoice_number ?? inv.external_ref}`
+        );
+      }
+    }
+  }
+
   // Only advance the cursor on a clean write — otherwise we'd skip rows we failed
   // to persist on the next run.
   if (errors.length === 0) await markSynced();
@@ -228,6 +262,7 @@ export async function syncXeroRevenue(): Promise<XeroSyncResult> {
     upserted,
     skipped,
     linked_orgs: linkedOrgs,
+    superseded,
     tenant: access.tenantName,
     errors,
   };

--- a/supabase/migrations/20260611120000_revenue_events_superseded.sql
+++ b/supabase/migrations/20260611120000_revenue_events_superseded.sql
@@ -1,0 +1,15 @@
+-- Hall pipeline "Por cerrar": when an opportunity is marked Won from the Hall,
+-- a manual revenue_event (source='hall', stage='sold') is created so the
+-- commitment counts against the quarter target immediately. When the real
+-- Xero invoice later arrives for the same organization, the manual sold row
+-- must stop counting or the card double-counts. These columns let the Xero
+-- sync supersede the manual row instead of deleting it (audit trail stays).
+
+alter table public.revenue_events
+  add column if not exists superseded_at timestamptz,
+  add column if not exists superseded_by text;
+
+comment on column public.revenue_events.superseded_at is
+  'Set when this (manual/hall) event was replaced by a real invoice row. Superseded rows are excluded from revenue sums.';
+comment on column public.revenue_events.superseded_by is
+  'external_ref (Xero InvoiceID) of the invoice row that superseded this event.';


### PR DESCRIPTION
Pipeline section under the Revenue card (Proposal Sent / Active-with-value opps), won/lost actions wired to /api/opportunity-outcome, sold-placeholder reconciliation in the Xero sync (superseded_at), and Proposal Sent propagated to existing status readers. Migration already applied to prod Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)