### PR TITLE
feat(stb): project linkage at ingest time + plan curation UI + backfill

### DIFF
--- a/docs/SUGGESTED_TIME_BLOCKS.md
+++ b/docs/SUGGESTED_TIME_BLOCKS.md
@@ -4,6 +4,32 @@ Feature that proposes **when** to execute the top priorities surfaced in
 the Hall. Reads Google Calendar availability + Supabase loops/opportunities
 + upcoming meetings → returns 3–5 specific time blocks with clear outcomes.
 
+## Meeting decision model (2026-06-11)
+
+One question decides whether a meeting costs calendar time: **is there work
+of Jose's to produce?**
+
+| Owed? (open commitment matches) | Material? (history with attendees) | Result |
+|---|---|---|
+| Yes | — | **PREP block** in STB (agenda/VIP only boost it) |
+| No  | Yes | **Retoma card** in the Hall agenda — auto punteo, zero calendar time (`src/lib/meeting-retomas.ts`) |
+| No  | No  | **Nothing** — VIP included. No material → no block, per STB v2's founding rule |
+
+Prep and retoma share the same commitment rows and the same matcher
+(`commitmentMatchesMeeting`), so they can never both fire for one meeting.
+Retomas are deterministic (no LLM): last touch + transcript-summary bullets
+(`sources.processed_summary`) + open chase items.
+
+## Project context chip
+
+Every persisted block carries `project_name` / `objective_title` /
+`objective_tier` / `project_source` (migration `20260611130000`), resolved at
+generation time by `src/lib/project-context.ts`: explicit FK linkage when the
+source row has it, conservative unambiguous name inference otherwise
+(`project_source = 'inferred'`, rendered with a `~`). Tier is never inferred —
+it only appears through explicit `strategic_objective_id` or
+`strategic_objectives.linked_projects` linkage.
+
 ## Status
 
 - **Implemented, deployed, type-clean, observability in place.**

--- a/docs/SUGGESTED_TIME_BLOCKS.md
+++ b/docs/SUGGESTED_TIME_BLOCKS.md
@@ -30,6 +30,17 @@ source row has it, conservative unambiguous name inference otherwise
 it only appears through explicit `strategic_objective_id` or
 `strategic_objectives.linked_projects` linkage.
 
+Explicit linkage is populated at INGEST time (2026-06-11): the Fireflies and
+Gmail ingestors stamp `action_items.project_id` via
+`src/lib/ingestors/project-linkage.ts` (explicit `evidence.project_notion_id`
+→ same conservative name matcher → unambiguous single-project counterparty),
+and `persist.ts` fill-only patches linkage onto existing open rows as new
+motion arrives. One-shot catch-up for old rows:
+`POST /api/backfill-action-item-projects` (dry-run by default).
+`strategic_objectives.linked_projects` is curated by hand in the
+`/admin/plan` objective drawer ("Proyectos vinculados") — that linkage is the
+only path that activates tier on the chips.
+
 ## Status
 
 - **Implemented, deployed, type-clean, observability in place.**

--- a/src/app/admin/plan/page.tsx
+++ b/src/app/admin/plan/page.tsx
@@ -6,6 +6,7 @@ import {
   summarizeRevenue,
   currentQuarter,
 } from "@/lib/plan";
+import { loadActiveProjects } from "@/lib/project-context";
 import PlanView from "@/components/plan/PlanView";
 import { PlanNav } from "@/components/plan/PlanNav";
 
@@ -14,11 +15,15 @@ export const dynamic = "force-dynamic";
 export default async function PlanPage() {
   await requireAdmin();
 
-  const [objectives2026, objectives2027, revenueEvents2026] = await Promise.all([
+  const [objectives2026, objectives2027, revenueEvents2026, activeProjects] = await Promise.all([
     getObjectivesForYear(2026),
     getObjectivesForYear(2027),
     getRevenueEventsForYear(2026),
+    loadActiveProjects().catch(() => []),
   ]);
+  const projectOptions = activeProjects
+    .map(p => ({ id: p.id, name: p.name }))
+    .sort((a, b) => a.name.localeCompare(b.name, "es"));
 
   const revenue2026 = summarizeRevenue(objectives2026, revenueEvents2026);
   const { quarter } = currentQuarter();
@@ -97,6 +102,7 @@ export default async function PlanPage() {
             objectives2027={objectives2027}
             revenue2026={revenue2026}
             currentQuarter={quarter ?? 2}
+            projectOptions={projectOptions}
           />
         </div>
       </main>

--- a/src/app/api/backfill-action-item-projects/route.ts
+++ b/src/app/api/backfill-action-item-projects/route.ts
@@ -1,0 +1,144 @@
+/**
+ * POST /api/backfill-action-item-projects
+ *
+ * One-shot backfill: resolves project_id for OPEN action_items rows that
+ * have none, using the same conservative resolution the ingestors now apply
+ * at write time (see src/lib/ingestors/project-linkage.ts):
+ *
+ *   1. explicit — Fireflies items: source_id is an evidence.id; when that
+ *      evidence row carries project_notion_id, map it to projects.id.
+ *   2. inferred — unambiguous name match between the item's text
+ *      (subject + next_action + counterparty — same text the STB candidate
+ *      layer uses) and active project names. Ambiguous → untouched.
+ *
+ * Never overwrites: only rows with project_id IS NULL are considered, and
+ * the UPDATE re-checks the null so a concurrent ingestor write wins.
+ *
+ * Auth: admin session OR CRON_SECRET (Bearer / x-agent-key).
+ *
+ * Input body (all optional):
+ *   - dry_run: boolean (default TRUE — report matches without writing)
+ *   - limit: number (default 200)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServerClient } from "@/lib/supabase-server";
+import { adminGuardApi } from "@/lib/require-admin";
+import { loadProjectLinkage, resolveProjectIdForSignal } from "@/lib/ingestors/project-linkage";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+async function isAuthorized(req: NextRequest): Promise<boolean> {
+  const agentKey = req.headers.get("x-agent-key");
+  const cronKey  = req.headers.get("authorization");
+  const expected = process.env.CRON_SECRET;
+  if (expected && (agentKey === expected || cronKey === `Bearer ${expected}`)) return true;
+  const denied = await adminGuardApi();
+  return denied === null;
+}
+
+type OpenItem = {
+  id: string;
+  subject: string;
+  next_action: string | null;
+  counterparty: string | null;
+  source_type: string;
+  source_id: string;
+};
+
+export async function POST(req: NextRequest) {
+  if (!(await isAuthorized(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { dry_run?: boolean; limit?: number } = {};
+  try { body = await req.json(); } catch { /* empty body ok */ }
+  const dryRun = body.dry_run ?? true;
+  const limit  = Math.min(Math.max(body.limit ?? 200, 1), 1000);
+
+  const sb = getSupabaseServerClient();
+
+  const { data, error } = await sb
+    .from("action_items")
+    .select("id, subject, next_action, counterparty, source_type, source_id")
+    .eq("status", "open")
+    .is("project_id", null)
+    .limit(limit);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const items = (data ?? []) as OpenItem[];
+  if (items.length === 0) {
+    return NextResponse.json({ dry_run: dryRun, scanned: 0, matched: 0, updated: 0, items: [] });
+  }
+
+  const linkage = await loadProjectLinkage();
+  if (!linkage) {
+    return NextResponse.json({ error: "active-project load failed — see logs" }, { status: 500 });
+  }
+  const nameById = new Map(linkage.projects.map(p => [p.id, p.name]));
+
+  // Fireflies items reference evidence rows that may carry an explicit
+  // project_notion_id — fetch those in one batch.
+  const evidenceIds = items.filter(i => i.source_type === "fireflies").map(i => i.source_id);
+  const evidenceProject = new Map<string, string | null>();
+  if (evidenceIds.length > 0) {
+    const { data: evs } = await sb
+      .from("evidence")
+      .select("id, project_notion_id")
+      .in("id", evidenceIds);
+    for (const e of (evs ?? []) as Array<{ id: string; project_notion_id: string | null }>) {
+      evidenceProject.set(e.id, e.project_notion_id);
+    }
+  }
+
+  const report: Array<{
+    id: string; subject: string; method: "explicit" | "inferred";
+    project_id: string; project_name: string;
+  }> = [];
+  const errors: string[] = [];
+  let updated = 0;
+
+  for (const item of items) {
+    const explicitNotionId = item.source_type === "fireflies"
+      ? evidenceProject.get(item.source_id) ?? null
+      : null;
+    const inferText = `${item.subject} ${item.next_action ?? ""} ${item.counterparty ?? ""}`;
+
+    // Same precedence as ingest: explicit linkage wins; an explicit pointer
+    // to a dead project blocks inference (resolveProjectIdForSignal handles
+    // that), so try explicit-only first, then inference-only.
+    const projectId = explicitNotionId
+      ? resolveProjectIdForSignal(linkage, { projectNotionId: explicitNotionId })
+      : resolveProjectIdForSignal(linkage, { inferText });
+    if (!projectId) continue;
+
+    report.push({
+      id: item.id,
+      subject: item.subject,
+      method: explicitNotionId ? "explicit" : "inferred",
+      project_id: projectId,
+      project_name: nameById.get(projectId) ?? "(unknown)",
+    });
+
+    if (!dryRun) {
+      // .is("project_id", null) re-check: a concurrent ingestor write wins.
+      const { error: updErr } = await sb
+        .from("action_items")
+        .update({ project_id: projectId })
+        .eq("id", item.id)
+        .is("project_id", null);
+      if (updErr) errors.push(`${item.id}: ${updErr.message}`);
+      else updated++;
+    }
+  }
+
+  return NextResponse.json({
+    dry_run: dryRun,
+    scanned: items.length,
+    matched: report.length,
+    updated,
+    ...(errors.length ? { errors } : {}),
+    items: report,
+  });
+}

--- a/src/app/api/stb-debug/route.ts
+++ b/src/app/api/stb-debug/route.ts
@@ -2,13 +2,20 @@
  * GET /api/stb-debug
  *
  * Diagnostic endpoint — lists the current working-hour slots, the candidates
- * the matcher would see, and the score each candidate would receive per slot.
- * Read-only; does not create or expire anything. Admin-guarded.
+ * the matcher would see, the score each candidate would receive per slot,
+ * the resolved project context per candidate, and the retomas the Hall
+ * agenda would show. Read-only; does not create or expire anything.
  *
- * Purpose: debug scheduling decisions (e.g. why Friday was chosen over Monday).
+ * Auth: Clerk admin, or `Authorization: Bearer <CRON_SECRET>` /
+ * `x-agent-key: <CRON_SECRET>` for headless verification (same pattern as
+ * prep-meeting-brief). Bearer callers may pass ?email= to use a specific
+ * user's hall preferences; otherwise defaults apply.
+ *
+ * Purpose: debug scheduling decisions (e.g. why Friday was chosen over
+ * Monday, why a meeting got prep vs retoma vs nothing).
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { adminGuardApi } from "@/lib/require-admin";
 import {
@@ -30,16 +37,30 @@ import {
   loadAttendeeClasses,
 } from "@/lib/meeting-classifier";
 import { getHallPreferences } from "@/lib/hall-preferences";
+import { resolveProjectContexts } from "@/lib/project-context";
+import { buildRetomas } from "@/lib/meeting-retomas";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  const guard = await adminGuardApi();
-  if (guard) return guard;
+function bearerAuthed(req: NextRequest): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false;
+  const auth = req.headers.get("authorization") ?? "";
+  const agent = req.headers.get("x-agent-key") ?? "";
+  return auth === `Bearer ${expected}` || agent === expected;
+}
 
-  const user = await currentUser();
-  const email = user?.primaryEmailAddress?.emailAddress;
-  if (!email) return NextResponse.json({ error: "No email" }, { status: 400 });
+export async function GET(req: NextRequest) {
+  let email: string | undefined;
+  if (bearerAuthed(req)) {
+    email = new URL(req.url).searchParams.get("email") ?? "stb-debug";
+  } else {
+    const guard = await adminGuardApi();
+    if (guard) return guard;
+    const user = await currentUser();
+    email = user?.primaryEmailAddress?.emailAddress;
+    if (!email) return NextResponse.json({ error: "No email" }, { status: 400 });
+  }
 
   const prefs = await getHallPreferences(email);
   const now = new Date();
@@ -72,15 +93,38 @@ export async function GET() {
     ...(batchCand ? [batchCand] : []),
   ];
 
+  // ?inferTest=<text> — dry-run the project-context inference on arbitrary
+  // text ("why didn't this block get a chip?") without touching real blocks.
+  const inferTest = new URL(req.url).searchParams.get("inferTest");
+  const inferTestResult = inferTest
+    ? (await resolveProjectContexts([{
+        title: inferTest, entity_type: "commitment", entity_id: "infer_test",
+        entity_label: inferTest, duration_min: 0, task_type: "admin",
+        urgency_score: 0, confidence_score: 0, why_now: "", expected_outcome: "",
+        fingerprint: "infer_test", project_ref: { infer_text: inferTest },
+      }])).get("infer_test") ?? null
+    : null;
+
+  // The new decision-model surfaces: project context chips + retomas.
+  const projectContexts = await resolveProjectContexts(allCands);
+  const retomas = await buildRetomas(upcoming.map(m => ({
+    eventId:        m.id,
+    title:          m.title,
+    startMs:        m.start.getTime(),
+    attendeeEmails: m.attendees.filter(a => !a.self).map(a => a.email),
+  })));
+
   // Compute per-slot scores the matcher would assign to each candidate.
   // Keep it minimal; do not invoke the real matcher (we want raw visibility).
   const TARGETS: Record<string, { min: number; max: number }> = {
-    deep_work: { min: 90, max: 180 },
-    decision:  { min: 40, max:  90 },
-    prep:      { min: 40, max:  90 },
-    follow_up: { min: 20, max:  45 },
-    admin:     { min: 20, max:  45 },
+    deep_work:  { min: 90, max: 180 },
+    decision:   { min: 40, max:  90 },
+    prep:       { min: 40, max:  90 },
+    follow_up:  { min: 20, max:  45 },
+    admin:      { min: 20, max:  45 },
+    commitment: { min: 40, max: 120 },
   };
+  const FALLBACK_TARGET = { min: 30, max: 90 };
 
   const slotBrief = slots.map(s => ({
     start: s.start.toISOString(),
@@ -91,7 +135,7 @@ export async function GET() {
   }));
 
   const analysed = allCands.map(c => {
-    const target = TARGETS[c.task_type];
+    const target = TARGETS[c.task_type] ?? FALLBACK_TARGET;
     const mid = (target.min + target.max) / 2;
     const perSlot = slots.map((s, idx) => {
       let score = c.urgency_score;
@@ -122,6 +166,7 @@ export async function GET() {
       urgency_score: c.urgency_score,
       fingerprint: c.fingerprint,
       entity_label: c.entity_label,
+      project_context: projectContexts.get(c.fingerprint) ?? null,
       hard_time_constraint: c.hard_time_constraint
         ? { kind: c.hard_time_constraint.kind, reference: c.hard_time_constraint.reference.toISOString() }
         : null,
@@ -143,5 +188,18 @@ export async function GET() {
     slots: slotBrief,
     candidate_count: allCands.length,
     candidates: analysed,
+    ...(inferTest ? { infer_test: { text: inferTest, result: inferTestResult } } : {}),
+    meeting_decision_model: {
+      upcoming_meetings: upcoming.map(m => {
+        const prep = prepCands.find(p => p.entity_id === m.id);
+        const retoma = retomas.get(m.id);
+        return {
+          title: m.title,
+          start: m.start.toISOString(),
+          decision: prep ? "prep_block" : retoma ? "retoma" : "nothing",
+          retoma: retoma ?? null,
+        };
+      }),
+    },
   });
 }

--- a/src/app/api/suggested-time-blocks/route.ts
+++ b/src/app/api/suggested-time-blocks/route.ts
@@ -11,10 +11,11 @@
  *   3. Build candidates from:
  *        - open commitments (action_items extracted from meeting transcripts
  *          / email — session/focused effort only; quick items batch-sweep)
- *        - evidence-gated meeting preps (open items with attendee / real
- *          agenda / VIP — never "every meeting deserves prep")
+ *        - owed-work meeting preps (ONLY when an open commitment involves an
+ *          attendee / the meeting subject — agenda or VIP alone never creates
+ *          a block; those meetings get a Retoma card in the Hall agenda)
  *        - loops + opportunities (already content-based)
- *      A meeting with no extracted commitments produces NO follow-up block.
+ *      A meeting with no extracted commitments produces NO prep/follow-up block.
  *   4. Remove candidates whose fingerprint is dismissed or snoozed for this
  *      user (meeting-prep dismissals suppress the recurring series for 7d)
  *   5. Greedy match with confidence floor → up to 5 suggestions (cap, not quota)
@@ -45,6 +46,7 @@ import {
   loopCoveredEntityIds,
 } from "@/lib/time-block-candidates";
 import { matchCandidatesToSlots } from "@/lib/time-block-matcher";
+import { resolveProjectContexts } from "@/lib/project-context";
 import { getHallPreferences } from "@/lib/hall-preferences";
 import { classifyGoogleError } from "@/lib/google-auth";
 import { logHallEvent } from "@/lib/hall-events";
@@ -77,6 +79,10 @@ type StoredBlock = {
   status: string;
   generated_at: string;
   gcal_event_link: string | null;
+  project_name: string | null;
+  objective_title: string | null;
+  objective_tier: string | null;
+  project_source: string | null;
 };
 
 export async function GET(req: NextRequest) {
@@ -99,7 +105,7 @@ export async function GET(req: NextRequest) {
   // ── Step 1: check if stored set is still fresh ──────────────────────────
   const { data: existing } = await sb
     .from("suggested_time_blocks")
-    .select("id,title,linked_entity_type,linked_entity_id,linked_entity_label,suggested_start_time,suggested_end_time,duration_minutes,task_type,urgency_score,confidence_score,why_now,expected_outcome,fingerprint,status,generated_at,gcal_event_link")
+    .select("id,title,linked_entity_type,linked_entity_id,linked_entity_label,suggested_start_time,suggested_end_time,duration_minutes,task_type,urgency_score,confidence_score,why_now,expected_outcome,fingerprint,status,generated_at,gcal_event_link,project_name,objective_title,objective_tier,project_source")
     .eq("user_email", email)
     .eq("status", "suggested")
     .gte("suggested_start_time", nowIso)
@@ -257,6 +263,10 @@ export async function GET(req: NextRequest) {
       .eq("user_email", email)
       .eq("status", "suggested");
 
+    // Project / objective context — so each block answers "which project,
+    // what tier of the plan" without Jose having to guess priority.
+    const projectContexts = await resolveProjectContexts(matches.map(m => m.candidate));
+
     // Insert fresh rows — cap the actual start/end to the right-sized block so
     // the Google Calendar event we later create is never the full open slot.
     // Without this cap, a 45-minute prep task dropped into a 4-hour slot would
@@ -265,6 +275,7 @@ export async function GET(req: NextRequest) {
       const cappedMin  = Math.min(m.slot.durationMin, m.candidate.duration_min + 15);
       const startDate  = m.slot.start;
       const endDate    = new Date(startDate.getTime() + cappedMin * 60_000);
+      const ctx        = projectContexts.get(m.candidate.fingerprint);
       return {
         user_email:           email,
         title:                m.candidate.title,
@@ -281,12 +292,16 @@ export async function GET(req: NextRequest) {
         expected_outcome:     m.candidate.expected_outcome,
         fingerprint:          m.candidate.fingerprint,
         status:               "suggested",
+        project_name:         ctx?.project_name ?? null,
+        objective_title:      ctx?.objective_title ?? null,
+        objective_tier:       ctx?.objective_tier ?? null,
+        project_source:       ctx?.project_source ?? null,
       };
     });
     const { data: saved, error: insertErr } = await sb
       .from("suggested_time_blocks")
       .insert(inserted)
-      .select("id,title,linked_entity_type,linked_entity_id,linked_entity_label,suggested_start_time,suggested_end_time,duration_minutes,task_type,urgency_score,confidence_score,why_now,expected_outcome,fingerprint,status,generated_at,gcal_event_link");
+      .select("id,title,linked_entity_type,linked_entity_id,linked_entity_label,suggested_start_time,suggested_end_time,duration_minutes,task_type,urgency_score,confidence_score,why_now,expected_outcome,fingerprint,status,generated_at,gcal_event_link,project_name,objective_title,objective_tier,project_source");
 
     if (insertErr) {
       return NextResponse.json({ error: "insert_failed", message: insertErr.message }, { status: 500 });
@@ -395,6 +410,10 @@ function formatForClient(row: StoredBlock, tz: string) {
     expected_outcome:   row.expected_outcome,
     status:             row.status,
     gcal_event_link:    row.gcal_event_link,
+    project_name:       row.project_name,
+    objective_title:    row.objective_title,
+    objective_tier:     row.objective_tier,
+    project_source:     row.project_source,
     slot_label:         formatSlotLabel({
       start: new Date(row.suggested_start_time),
       end:   new Date(row.suggested_end_time),

--- a/src/components/HallTodayAgenda.tsx
+++ b/src/components/HallTodayAgenda.tsx
@@ -4,6 +4,7 @@ import { getSelfEmails } from "@/lib/hall-self";
 import { getContactsByEmails } from "@/lib/contacts";
 import { getHallPreferences } from "@/lib/hall-preferences";
 import { logServerError } from "@/lib/debug-log";
+import { buildRetomas, type Retoma } from "@/lib/meeting-retomas";
 
 type CalRow = {
   event_id: string;
@@ -32,6 +33,9 @@ type CompactMeeting = {
   attendeeCount: number;
   attendeeNames: string[];
   htmlLink: string | null;
+  /** Read-before-you-walk-in pointer. Only set when the meeting has prior
+   *  history and nothing owed (owed → STB prep block instead). */
+  retoma: Retoma | null;
 };
 
 // Calendar-date key in the user's timezone (en-CA → "2026-06-10"). Server runs
@@ -255,6 +259,15 @@ export async function HallTodayAgenda({ userEmail }: { userEmail?: string } = {}
   };
 
   // ── Compact data for the rest of today ───────────────────────────────────
+  // Retomas: deterministic "lo último que se habló" pointers for repeat
+  // meetings ≤48h out with nothing owed (owed work gets an STB prep block).
+  const retomas = await buildRetomas(restRows.map(r => ({
+    eventId:        r.event_id,
+    title:          r.event_title,
+    startMs:        new Date(r.event_start).getTime(),
+    attendeeEmails: (r.attendee_emails ?? []).filter(e => e && !selfSet.has(e.toLowerCase())),
+  })));
+
   const rest: CompactMeeting[] = restRows.map(r => {
     const others = (r.attendee_emails ?? []).filter(e => e && !selfSet.has(e.toLowerCase()));
     const names = others.map(e => {
@@ -270,6 +283,7 @@ export async function HallTodayAgenda({ userEmail }: { userEmail?: string } = {}
       attendeeCount: others.length,
       attendeeNames: names.slice(0, 3),
       htmlLink:      r.html_link ?? null,
+      retoma:        retomas.get(r.event_id) ?? null,
     };
   });
 
@@ -459,6 +473,39 @@ export async function HallTodayAgenda({ userEmail }: { userEmail?: string } = {}
                             {m.attendeeNames.join(", ")}
                             {m.attendeeCount > 3 && ` +${m.attendeeCount - 3}`}
                           </p>
+                        )}
+                        {m.retoma && (
+                          <div
+                            className="mt-2 pl-2.5 py-1.5 pr-2"
+                            style={{ borderLeft: "2px solid var(--hall-stroke-0)", background: "var(--hall-paper-1)", borderRadius: "0 4px 4px 0" }}
+                          >
+                            <p
+                              className="font-bold uppercase mb-1"
+                              style={{ fontSize: 8, letterSpacing: "0.18em", color: "var(--hall-muted-3)", fontFamily: "var(--font-hall-mono)" }}
+                            >
+                              Retoma · {m.retoma.lastTouch.kind === "Meeting" ? "last met" : "last email"} {dayKey(new Date(m.retoma.lastTouch.at), tz)}
+                            </p>
+                            {m.retoma.bullets.length > 0 ? (
+                              <ul className="flex flex-col gap-0.5">
+                                {m.retoma.bullets.map((b, i) => (
+                                  <li key={i} className="text-[10.5px] leading-[1.45] pl-3 relative" style={{ color: "var(--hall-ink-3)" }}>
+                                    <span className="absolute left-0" style={{ fontFamily: "var(--font-hall-mono)", color: "var(--hall-muted-3)" }}>·</span>
+                                    {b}
+                                  </li>
+                                ))}
+                              </ul>
+                            ) : (
+                              <p className="text-[10.5px] leading-snug line-clamp-1" style={{ color: "var(--hall-ink-3)" }}>
+                                {m.retoma.lastTouch.title}
+                              </p>
+                            )}
+                            {m.retoma.waitingOnThem.length > 0 && (
+                              <p className="text-[10px] mt-1 leading-snug" style={{ color: "var(--hall-muted-2)" }}>
+                                <span className="font-semibold" style={{ color: "var(--hall-ink-3)" }}>Waiting on them: </span>
+                                {m.retoma.waitingOnThem.join(" · ")}
+                              </p>
+                            )}
+                          </div>
                         )}
                       </div>
                       <span

--- a/src/components/SuggestedTimeBlocks.tsx
+++ b/src/components/SuggestedTimeBlocks.tsx
@@ -32,6 +32,10 @@ type Suggestion = {
   status: string;
   gcal_event_link: string | null;
   slot_label: string;
+  project_name: string | null;
+  objective_title: string | null;
+  objective_tier: string | null;     // 'high' | 'mid' | 'low'
+  project_source: string | null;     // 'explicit' | 'inferred'
 };
 
 type ApiResponse =
@@ -291,6 +295,29 @@ export function SuggestedTimeBlocks() {
                 >
                   {item.entity_label}
                 </p>
+                {(item.project_name || item.objective_tier) && (
+                  <p
+                    className="mt-1 truncate"
+                    style={{ fontFamily: "var(--font-hall-mono)", fontSize: 9.5, letterSpacing: "0.06em", color: "var(--hall-muted-2)" }}
+                    title={item.objective_title ? `Objective: ${item.objective_title}` : undefined}
+                  >
+                    <span
+                      style={{
+                        textTransform: "uppercase",
+                        background: "var(--hall-fill-soft)",
+                        padding: "1px 6px",
+                        borderRadius: 2,
+                        color: "var(--hall-ink-3)",
+                      }}
+                    >
+                      {item.project_name ?? "—"}
+                      {item.objective_tier && ` · ${item.objective_tier} tier`}
+                    </span>
+                    {item.project_source === "inferred" && (
+                      <span className="ml-1.5" style={{ color: "var(--hall-muted-3)" }}>~</span>
+                    )}
+                  </p>
+                )}
                 <p
                   className="text-[10.5px] sm:text-[11px] mt-1.5 leading-[1.5]"
                   style={{ color: "var(--hall-muted-2)" }}

--- a/src/components/plan/PlanView.tsx
+++ b/src/components/plan/PlanView.tsx
@@ -23,11 +23,15 @@ const METRICS: ObjectiveMetricType[] = [
   "milestone_binary", "event_attended", "asset_published", "mou_signed", "custom_sql",
 ];
 
+export type ProjectOption = { id: string; name: string };
+
 type Props = {
   objectives2026: StrategicObjective[];
   objectives2027: StrategicObjective[];
   revenue2026: QuarterRevenueSummary[];
   currentQuarter: number;
+  /** Active projects, for the linked_projects curation selector. */
+  projectOptions: ProjectOption[];
 };
 
 type TabKey = "annual-2026" | "q1-2026" | "q2-2026" | "q3-2026" | "q4-2026" | "q1-2027";
@@ -280,7 +284,7 @@ function AnnualAdjustedCell({ summaries }: { summaries: QuarterRevenueSummary[] 
 
 // ─── Main component ──────────────────────────────────────────────────────────
 
-export default function PlanView({ objectives2026, objectives2027, revenue2026, currentQuarter }: Props) {
+export default function PlanView({ objectives2026, objectives2027, revenue2026, currentQuarter, projectOptions }: Props) {
   const router = useRouter();
   const [tab, setTab] = useState<TabKey>(
     currentQuarter >= 1 && currentQuarter <= 4 ? (`q${currentQuarter}-2026` as TabKey) : "q2-2026"
@@ -432,6 +436,7 @@ export default function PlanView({ objectives2026, objectives2027, revenue2026, 
       {selected && (
         <ObjectiveDrawer
           obj={selected}
+          projectOptions={projectOptions}
           onClose={() => setSelected(null)}
           onSaved={(updated) => {
             setSelected(updated);
@@ -460,11 +465,12 @@ export default function PlanView({ objectives2026, objectives2027, revenue2026, 
 
 type DrawerProps = {
   obj: StrategicObjective;
+  projectOptions: ProjectOption[];
   onClose: () => void;
   onSaved: (updated: StrategicObjective) => void;
 };
 
-function ObjectiveDrawer({ obj, onClose, onSaved }: DrawerProps) {
+function ObjectiveDrawer({ obj, projectOptions, onClose, onSaved }: DrawerProps) {
   const [mode, setMode] = useState<"view" | "edit">("view");
   const progress =
     obj.target_value && obj.current_value != null
@@ -525,6 +531,7 @@ function ObjectiveDrawer({ obj, onClose, onSaved }: DrawerProps) {
         {mode === "edit" ? (
           <EditObjectiveForm
             obj={obj}
+            projectOptions={projectOptions}
             onCancel={() => setMode("view")}
             onSaved={(updated) => {
               onSaved(updated);
@@ -532,14 +539,24 @@ function ObjectiveDrawer({ obj, onClose, onSaved }: DrawerProps) {
             }}
           />
         ) : (
-          <ViewObjectiveBody obj={obj} progress={progress} />
+          <ViewObjectiveBody obj={obj} progress={progress} projectOptions={projectOptions} />
         )}
       </aside>
     </>
   );
 }
 
-function ViewObjectiveBody({ obj, progress }: { obj: StrategicObjective; progress: number | null }) {
+function ViewObjectiveBody({
+  obj,
+  progress,
+  projectOptions,
+}: {
+  obj: StrategicObjective;
+  progress: number | null;
+  projectOptions: ProjectOption[];
+}) {
+  const projectName = (id: string) =>
+    projectOptions.find((p) => p.id === id)?.name ?? `${id.slice(0, 8)}…`;
   return (
         <div className="px-7 py-6 space-y-5">
           <DrawerField label="Descripción" value={obj.description} />
@@ -628,8 +645,15 @@ function ViewObjectiveBody({ obj, progress }: { obj: StrategicObjective; progres
               {obj.linked_projects.length > 0 && (
                 <div className="mb-1.5">
                   <span className="text-[10px] text-[#0a0a0a]/60">Projects: </span>
-                  <span className="text-[11px] font-semibold text-[#0a0a0a]">
-                    {obj.linked_projects.length}
+                  <span className="inline-flex flex-wrap gap-1 align-middle">
+                    {obj.linked_projects.map((pid) => (
+                      <span
+                        key={pid}
+                        className="text-[10px] font-semibold px-2 py-0.5 rounded bg-[#f4f4ef] text-[#0a0a0a]"
+                      >
+                        {projectName(pid)}
+                      </span>
+                    ))}
                   </span>
                 </div>
               )}
@@ -663,10 +687,12 @@ function ViewObjectiveBody({ obj, progress }: { obj: StrategicObjective; progres
 
 function EditObjectiveForm({
   obj,
+  projectOptions,
   onCancel,
   onSaved,
 }: {
   obj: StrategicObjective;
+  projectOptions: ProjectOption[];
   onCancel: () => void;
   onSaved: (updated: StrategicObjective) => void;
 }) {
@@ -686,6 +712,8 @@ function EditObjectiveForm({
     JSON.stringify(obj.metric_params ?? {}, null, 2)
   );
   const [notes, setNotes] = useState(obj.notes ?? "");
+  const [linkedProjects, setLinkedProjects] = useState<string[]>(obj.linked_projects ?? []);
+  const [projectFilter, setProjectFilter] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -717,6 +745,7 @@ function EditObjectiveForm({
           target_unit: targetUnit.trim() || null,
           metric_type: metricType,
           metric_params: parsedParams,
+          linked_projects: linkedProjects,
           notes: notes.trim() || null,
         }),
       });
@@ -881,6 +910,56 @@ function EditObjectiveForm({
           />
         </FormField>
       )}
+
+      <FormField label={`Proyectos vinculados (${linkedProjects.length})`}>
+        <p className="text-[10px] text-[#0a0a0a]/50 mb-1.5 leading-snug">
+          Esta vinculación activa el tier del objetivo en los chips de Suggested
+          Time Blocks — el tier nunca se infiere, solo viaja por acá.
+        </p>
+        {projectOptions.length === 0 ? (
+          <p className="text-[11px] text-[#0a0a0a]/40">No hay proyectos activos disponibles.</p>
+        ) : (
+          <>
+            <input
+              value={projectFilter}
+              onChange={(e) => setProjectFilter(e.target.value)}
+              placeholder="Filtrar proyectos…"
+              className="w-full text-[12px] px-3 py-1.5 mb-1.5 border border-[#e4e4dd] rounded-md focus:outline-none focus:border-[#0a0a0a]"
+            />
+            <div className="max-h-44 overflow-y-auto border border-[#e4e4dd] rounded-md divide-y divide-[#f4f4ef]">
+              {projectOptions
+                .filter((p) =>
+                  // selected projects always visible so unticking is one click
+                  linkedProjects.includes(p.id) ||
+                  p.name.toLowerCase().includes(projectFilter.toLowerCase())
+                )
+                .map((p) => {
+                  const checked = linkedProjects.includes(p.id);
+                  return (
+                    <label
+                      key={p.id}
+                      className={`flex items-center gap-2 px-3 py-1.5 cursor-pointer text-[11.5px] ${
+                        checked ? "bg-[#c6f24a]/15 font-semibold" : "hover:bg-[#f4f4ef]"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() =>
+                          setLinkedProjects((prev) =>
+                            checked ? prev.filter((id) => id !== p.id) : [...prev, p.id]
+                          )
+                        }
+                        className="accent-[#0a0a0a]"
+                      />
+                      <span className="truncate">{p.name}</span>
+                    </label>
+                  );
+                })}
+            </div>
+          </>
+        )}
+      </FormField>
 
       <FormField label="Notas">
         <textarea

--- a/src/lib/calendar-slots.ts
+++ b/src/lib/calendar-slots.ts
@@ -41,9 +41,9 @@ export type MeetingAttendee = {
 export type UpcomingMeeting = {
   id: string;
   title: string;
-  /** Raw meeting description from Google Calendar. Used to gate prep tasks:
-   * a meeting with no context (no description, no VIP, no multi-party invite
-   * list) does not deserve a prep block. */
+  /** Raw meeting description from Google Calendar. A real agenda here boosts
+   * an owed-work prep block (duration/why-now) but never creates one on its
+   * own — see candidatesFromMeetings in time-block-candidates.ts. */
   description: string;
   start: Date;
   end: Date;

--- a/src/lib/ingestors/fireflies.ts
+++ b/src/lib/ingestors/fireflies.ts
@@ -19,7 +19,10 @@
  * Out of scope (later):
  *  - Deadline extraction (evidence doesn't store deadlines structurally)
  *  - Cross-source dedup tuning beyond the dedup_key default
- *  - Project/objective linkage (project_id filled when evidence has one)
+ *
+ * Project linkage (v1.3): related_ids.project_id is stamped from
+ * evidence.project_notion_id (explicit), falling back to conservative name
+ * inference over title + statement + meeting title. See project-linkage.ts.
  */
 
 import Anthropic from "@anthropic-ai/sdk";
@@ -27,6 +30,7 @@ import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { getSelfEmails } from "@/lib/hall-self";
 import { buildFactors } from "./priority";
 import { loadProjectRoles, passesManagementGate } from "./project-roles";
+import { loadProjectLinkage, resolveProjectIdForSignal } from "./project-linkage";
 import {
   getWatermark,
   startIngestorRun,
@@ -46,7 +50,7 @@ import type {
   Signal,
 } from "./types";
 
-const INGESTOR_VERSION = "fireflies@1.2.0";
+const INGESTOR_VERSION = "fireflies@1.3.0";
 const SOURCE_TYPE = "fireflies" as const;
 const DEFAULT_MAX_ITEMS = 60;
 const DEFAULT_BACKFILL_DAYS = 14;
@@ -116,8 +120,12 @@ export async function runFirefliesIngestor(input: IngestInput): Promise<IngestRe
     const sb = getSupabaseServerClient();
     const selfSet = await getSelfEmails();
 
-    // Management-level gate (Phase 11). Loaded once per run.
-    const projectRoles = await loadProjectRoles();
+    // Management-level gate (Phase 11) + project linkage map (v1.3).
+    // Loaded once per run.
+    const [projectRoles, projectLinkage] = await Promise.all([
+      loadProjectRoles(),
+      loadProjectLinkage(),
+    ]);
 
     // ─── Fetch evidence since watermark ─────────────────────────────────
     const rows = await fetchFirefliesEvidenceSince(since, input.maxItems ?? DEFAULT_MAX_ITEMS);
@@ -175,6 +183,13 @@ export async function runFirefliesIngestor(input: IngestInput): Promise<IngestRe
           founderOwned: false,
         });
 
+        // Project linkage: explicit evidence.project_notion_id first, then
+        // conservative name inference over the evidence text. Ambiguous → null.
+        const projectId = resolveProjectIdForSignal(projectLinkage, {
+          projectNotionId: row.project_notion_id,
+          inferText: `${row.title} ${row.evidence_statement ?? ""} ${row.meeting_title ?? ""}`,
+        });
+
         const signal: ActionSignal = {
           kind: "action",
           source_type: SOURCE_TYPE,
@@ -182,7 +197,7 @@ export async function runFirefliesIngestor(input: IngestInput): Promise<IngestRe
           source_url: row.source_url ?? "",
           emitted_at: new Date().toISOString(),
           ingestor_version: INGESTOR_VERSION,
-          related_ids: {},
+          related_ids: projectId ? { project_id: projectId } : {},
           payload: {
             intent,
             ball_in_court: ball,

--- a/src/lib/ingestors/gmail.ts
+++ b/src/lib/ingestors/gmail.ts
@@ -13,8 +13,11 @@
  * Out of scope (later):
  *  - chase intent (Jose sent last + >7d old)
  *  - deadline extraction from body
- *  - objective_link via project mapping
  *  - CH Sources conversation_id linkage (left null)
+ *
+ * Project linkage (v1.4): related_ids.project_id is stamped conservatively —
+ * name inference on the subject first, else the sender's CH People projects
+ * when they resolve to exactly ONE active project. See project-linkage.ts.
  */
 
 import Anthropic from "@anthropic-ai/sdk";
@@ -29,6 +32,7 @@ import {
   effectiveProjectFor,
   passesManagementGate,
 } from "./project-roles";
+import { loadProjectLinkage, resolveProjectIdForSignal } from "./project-linkage";
 import {
   getWatermark,
   startIngestorRun,
@@ -48,7 +52,7 @@ import type {
   Signal,
 } from "./types";
 
-const INGESTOR_VERSION = "gmail@1.3.0";
+const INGESTOR_VERSION = "gmail@1.4.0";
 const SOURCE_TYPE = "gmail" as const;
 const DEFAULT_MAX_ITEMS = 100;
 const DEFAULT_BACKFILL_DAYS = 7;
@@ -210,6 +214,9 @@ export async function runGmailIngestor(input: IngestInput): Promise<IngestResult
       ? await Promise.all([loadProjectRoles(), loadPersonProjectMap()])
       : [new Map(), new Map()];
 
+    // Active-project map for related_ids.project_id stamping (v1.4).
+    const projectLinkage = actionableThreads.length > 0 ? await loadProjectLinkage() : null;
+
     // ─── Build ActionSignals ────────────────────────────────────────────
     for (const t of actionableThreads) {
       // Haiku SKIP = drop. If next_action is null the LLM decided this isn't
@@ -261,6 +268,13 @@ export async function runGmailIngestor(input: IngestInput): Promise<IngestResult
         mentorshipPenalty,
       });
 
+      // Project linkage: subject-name inference first; else the sender's
+      // CH People projects when they collapse to exactly one active project.
+      const projectId = resolveProjectIdForSignal(projectLinkage, {
+        inferText: t.subject,
+        counterpartyProjectNotionIds: peopleProjectMap.get(t.fromEmail.toLowerCase()) ?? null,
+      });
+
       const signal: ActionSignal = {
         kind: "action",
         source_type: SOURCE_TYPE,
@@ -270,6 +284,7 @@ export async function runGmailIngestor(input: IngestInput): Promise<IngestResult
         ingestor_version: INGESTOR_VERSION,
         related_ids: {
           contact_id: contact?.id ?? undefined,
+          ...(projectId ? { project_id: projectId } : {}),
         },
         payload: {
           intent: "reply",

--- a/src/lib/ingestors/persist.ts
+++ b/src/lib/ingestors/persist.ts
@@ -131,6 +131,23 @@ export async function finishIngestorRun(params: {
 
 // ─── action_items ─────────────────────────────────────────────────────────
 /**
+ * Fill-only linkage patch: stamp project / objective ids from the signal
+ * when the existing row has none. Never overwrites a non-null linkage —
+ * curation and backfill decisions win over re-ingestion.
+ */
+function linkagePatch(
+  signal: ActionSignal,
+  existing: { project_id?: string | null; strategic_objective_id?: string | null },
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const pid = signal.related_ids?.project_id;
+  const oid = signal.related_ids?.objective_id;
+  if (pid && !existing.project_id) out.project_id = pid;
+  if (oid && !existing.strategic_objective_id) out.strategic_objective_id = oid;
+  return out;
+}
+
+/**
  * Upsert an ActionSignal into action_items.
  *
  * Behaviour:
@@ -158,7 +175,7 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
   // Look for an existing open row with the same dedup_key
   const { data: existing, error: selErr } = await sb
     .from("action_items")
-    .select("id, last_motion_at")
+    .select("id, last_motion_at, project_id, strategic_objective_id")
     .eq("dedup_key", dedup_key)
     .eq("status", "open")
     .maybeSingle();
@@ -188,6 +205,7 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
         // Only overwrite effort when the signal carries one — a null/absent
         // effort must not erase a value set by backfill or a prior classifier.
         ...(signal.payload.effort ? { effort: signal.payload.effort } : {}),
+        ...linkagePatch(signal, existing),
       })
       .eq("id", existing.id as string);
     if (updErr) throw new Error(`persistActionSignal update: ${updErr.message}`);
@@ -209,7 +227,7 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
   //      manual_dismiss are eligible
   const { data: closed } = await sb
     .from("action_items")
-    .select("id, status, resolved_at, resolved_reason, last_motion_at")
+    .select("id, status, resolved_at, resolved_reason, last_motion_at, project_id, strategic_objective_id")
     .eq("dedup_key", dedup_key)
     .in("status", ["resolved", "dismissed", "stale"])
     .order("resolved_at", { ascending: false })
@@ -244,6 +262,7 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
           deadline:         signal.payload.deadline,
           consequence:      signal.payload.consequence,
           ...(signal.payload.effort ? { effort: signal.payload.effort } : {}),
+          ...linkagePatch(signal, closed),
         })
         .eq("id", closed.id as string);
       if (reErr) throw new Error(`persistActionSignal reopen: ${reErr.message}`);
@@ -262,7 +281,7 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
   const FUZZY_THRESHOLD = 0.5;
   let fuzzyMatchQuery = sb
     .from("action_items")
-    .select("id, subject, last_motion_at")
+    .select("id, subject, last_motion_at, project_id, strategic_objective_id")
     .eq("status", "open")
     .eq("intent", signal.payload.intent)
     .limit(20);
@@ -280,7 +299,10 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
   if (fuzzyCandidates && fuzzyCandidates.length > 0) {
     const incomingFp = actionItemFingerprint(signal.payload.subject);
     if (incomingFp) {
-      let bestMatch: { id: string; lastMotion: string; similarity: number } | null = null;
+      let bestMatch: {
+        id: string; lastMotion: string; similarity: number;
+        project_id: string | null; strategic_objective_id: string | null;
+      } | null = null;
       for (const c of fuzzyCandidates) {
         const sim = overlapCoefficient(incomingFp, actionItemFingerprint(c.subject as string));
         if (sim >= FUZZY_THRESHOLD && (!bestMatch || sim > bestMatch.similarity)) {
@@ -288,6 +310,8 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
             id:         c.id as string,
             lastMotion: c.last_motion_at as string,
             similarity: sim,
+            project_id: (c.project_id as string | null) ?? null,
+            strategic_objective_id: (c.strategic_objective_id as string | null) ?? null,
           };
         }
       }
@@ -310,6 +334,7 @@ export async function persistActionSignal(signal: ActionSignal): Promise<{
             deadline:         signal.payload.deadline,
             consequence:      signal.payload.consequence,
             ...(signal.payload.effort ? { effort: signal.payload.effort } : {}),
+            ...linkagePatch(signal, bestMatch),
           })
           .eq("id", bestMatch.id);
         if (updErr) throw new Error(`persistActionSignal fuzzy-update: ${updErr.message}`);

--- a/src/lib/ingestors/project-linkage.ts
+++ b/src/lib/ingestors/project-linkage.ts
@@ -1,0 +1,90 @@
+/**
+ * project-linkage.ts — resolve action_items.project_id at INGEST time.
+ *
+ * Systemic fix for the empty-linkage problem: STB chips fell back to name
+ * inference at render time because no ingestor ever wrote
+ * action_items.project_id. This module lets every ingestor stamp the
+ * Supabase projects.id uuid on the signal when — and only when — the source
+ * maps to a known project unambiguously.
+ *
+ * Resolution order (first hit wins):
+ *   1. explicit  — the source row carries a project notion_id (Fireflies
+ *      evidence.project_notion_id). Authoritative.
+ *   2. inferred  — conservative name match between the signal's text and
+ *      active project names (same matcher as the STB chips; ambiguous → null).
+ *   3. person    — the counterparty is linked to EXACTLY ONE active project
+ *      in CH People. Two or more → null.
+ *
+ * Fail-soft: linkage is decoration on top of ingestion. loadProjectLinkage
+ * returns null on DB error (visibly logged) and resolveProjectIdForSignal
+ * degrades to null — ingestion must never break because of it.
+ */
+
+import {
+  loadActiveProjects,
+  inferProjectFromText,
+  type MatchableProject,
+} from "@/lib/project-context";
+
+export type ProjectLinkage = {
+  projects: MatchableProject[];
+  /** projects.notion_id → projects.id (active projects only) */
+  idByNotionId: Map<string, string>;
+};
+
+export async function loadProjectLinkage(): Promise<ProjectLinkage | null> {
+  try {
+    const projects = await loadActiveProjects();
+    const idByNotionId = new Map<string, string>();
+    for (const p of projects) {
+      if (p.notion_id) idByNotionId.set(p.notion_id, p.id);
+    }
+    return { projects, idByNotionId };
+  } catch (e) {
+    // Visible per the fallback observability rule — items land without
+    // project_id this run and the logs say why.
+    console.warn(
+      "[project-linkage] DEGRADED: active-project load failed —",
+      e instanceof Error ? e.message : e,
+    );
+    return null;
+  }
+}
+
+export function resolveProjectIdForSignal(
+  linkage: ProjectLinkage | null,
+  params: {
+    /** Explicit project notion_id on the source row, when it has one. */
+    projectNotionId?: string | null;
+    /** Free text for conservative name inference (subject, title, statement). */
+    inferText?: string | null;
+    /** Project notion_ids the counterparty is linked to in CH People. */
+    counterpartyProjectNotionIds?: string[] | null;
+  },
+): string | null {
+  if (!linkage) return null;
+
+  if (params.projectNotionId) {
+    const id = linkage.idByNotionId.get(params.projectNotionId);
+    if (id) return id;
+    // Explicit notion id pointing at a dead/unknown project: do NOT fall
+    // through to inference — the source said which project it was, and that
+    // project is not active. No link beats a contradictory one.
+    return null;
+  }
+
+  if (params.inferText) {
+    const match = inferProjectFromText(linkage.projects, params.inferText);
+    if (match) return match.id;
+  }
+
+  const cpIds = params.counterpartyProjectNotionIds ?? [];
+  if (cpIds.length > 0) {
+    const active = [...new Set(
+      cpIds.map(n => linkage.idByNotionId.get(n)).filter((x): x is string => !!x),
+    )];
+    if (active.length === 1) return active[0];
+  }
+
+  return null;
+}

--- a/src/lib/meeting-retomas.ts
+++ b/src/lib/meeting-retomas.ts
@@ -1,0 +1,211 @@
+/**
+ * meeting-retomas.ts
+ *
+ * Retoma cards — the light counterpart to STB meeting-prep blocks.
+ *
+ * Decision model (agreed 2026-06-11):
+ *   - Jose OWES the meeting something (open commitment matches) → PREP block
+ *     in Suggested Time Blocks. Calendar time is reserved only for owed work.
+ *   - Nothing owed, but there IS history with these attendees → RETOMA: an
+ *     auto-built read-before-you-walk-in pointer next to the day's agenda.
+ *     Costs zero calendar time.
+ *   - Nothing owed, no history → NOTHING. No material, no card.
+ *
+ * A retoma is fully deterministic — no LLM call. It assembles only what the
+ * system already knows:
+ *   - last touch        (latest transcript / email observation with overlap)
+ *   - what was discussed (bullets from sources.processed_summary of that
+ *                         transcript, when ingested)
+ *   - waiting on them   (open 'chase' items involving the attendees)
+ *
+ * Uses the SAME open-commitment rows and matcher as the STB prep gate, so
+ * prep and retoma can never both fire for one meeting.
+ */
+
+import { getSupabaseServerClient } from "./supabase-server";
+import {
+  commitmentMatchesMeeting,
+  fetchOpenCommitmentRows,
+  type CommitmentRow,
+} from "./time-block-candidates";
+import type { UpcomingMeeting } from "./calendar-slots";
+
+export type RetomaInput = {
+  eventId: string;
+  title: string;
+  startMs: number;
+  attendeeEmails: string[];   // non-self only
+};
+
+export type Retoma = {
+  eventId: string;
+  lastTouch: { kind: "Meeting" | "Email"; at: string; title: string };
+  /** What was discussed last time — from the transcript summary. May be empty. */
+  bullets: string[];
+  /** Open items where Jose is waiting on the counterpart. May be empty. */
+  waitingOnThem: string[];
+};
+
+const HORIZON_MS = 48 * 3600_000;   // retomas only for meetings ≤48h out
+const MAX_BULLETS = 3;
+
+/** commitmentMatchesMeeting needs an UpcomingMeeting; retomas start from
+ *  Supabase calendar rows, so build the minimal shape it actually reads
+ *  (title + attendee emails). */
+function asMatcherMeeting(m: RetomaInput): UpcomingMeeting {
+  return {
+    id:             m.eventId,
+    title:          m.title,
+    description:    "",
+    start:          new Date(m.startMs),
+    end:            new Date(m.startMs),
+    attendeeCount:  m.attendeeEmails.length,
+    organizerEmail: null,
+    htmlLink:       "",
+    attendees:      m.attendeeEmails.map(email => ({
+      email: email.toLowerCase(),
+      displayName: null,
+      responseStatus: "unknown" as const,
+      self: false,
+    })),
+  };
+}
+
+/** "- **Topic:** detail" markdown lines → plain bullet strings. Falls back
+ *  to sentence-ish lines when the summary isn't bulleted. */
+function bulletize(summary: string | null): string[] {
+  if (!summary) return [];
+  const lines = summary.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  const bullets = lines
+    .filter(l => /^[-*•·]\s+\S/.test(l))
+    .map(l => l.replace(/^[-*•·]\s+/, "").replace(/\*\*/g, "").trim());
+  const pool = bullets.length > 0 ? bullets : lines.map(l => l.replace(/\*\*/g, ""));
+  return pool
+    .filter(Boolean)
+    .slice(0, MAX_BULLETS)
+    .map(b => (b.length > 150 ? b.slice(0, 147) + "…" : b));
+}
+
+type Observation = {
+  kind: "Meeting" | "Email";
+  at: string;
+  title: string;
+  participants: string[];
+  transcriptId: string | null;
+};
+
+export async function buildRetomas(meetings: RetomaInput[]): Promise<Map<string, Retoma>> {
+  const out = new Map<string, Retoma>();
+  const now = Date.now();
+  const inWindow = meetings.filter(
+    m => m.startMs > now && m.startMs - now <= HORIZON_MS && m.attendeeEmails.length > 0,
+  );
+  if (inWindow.length === 0) return out;
+
+  try {
+    const sb = getSupabaseServerClient();
+    const allEmails = [...new Set(inWindow.flatMap(m => m.attendeeEmails.map(e => e.toLowerCase())))];
+
+    const [openRows, txRes, mailRes, chaseRes] = await Promise.all([
+      fetchOpenCommitmentRows(50),
+      sb.from("hall_transcript_observations")
+        .select("transcript_id,title,meeting_at,participant_emails")
+        .overlaps("participant_emails", allEmails)
+        .order("meeting_at", { ascending: false })
+        .limit(40),
+      sb.from("hall_email_observations")
+        .select("subject,last_message_at,attendee_emails")
+        .overlaps("attendee_emails", allEmails)
+        .order("last_message_at", { ascending: false })
+        .limit(40),
+      // "Waiting on them": chase/nurture intents are excluded from
+      // fetchOpenCommitmentRows' block intents but are exactly retoma material.
+      sb.from("action_items")
+        .select("id, subject, counterparty, next_action, intent, effort, deadline, priority_score, last_motion_at, first_surfaced_at, source_type, source_url, project_id, strategic_objective_id")
+        .eq("status", "open")
+        .in("intent", ["chase", "nurture"])
+        .limit(30),
+    ]);
+
+    const observations: Observation[] = [
+      ...((txRes.data ?? []) as { transcript_id: string; title: string | null; meeting_at: string | null; participant_emails: string[] | null }[])
+        .filter(r => r.meeting_at)
+        .map(r => ({
+          kind: "Meeting" as const, at: r.meeting_at!, title: r.title ?? "Meeting",
+          participants: (r.participant_emails ?? []).map(e => e.toLowerCase()),
+          transcriptId: r.transcript_id,
+        })),
+      ...((mailRes.data ?? []) as { subject: string | null; last_message_at: string | null; attendee_emails: string[] | null }[])
+        .filter(r => r.last_message_at)
+        .map(r => ({
+          kind: "Email" as const, at: r.last_message_at!, title: r.subject ?? "Email",
+          participants: (r.attendee_emails ?? []).map(e => e.toLowerCase()),
+          transcriptId: null,
+        })),
+    ].sort((a, b) => new Date(b.at).getTime() - new Date(a.at).getTime());
+
+    const chaseRows = (chaseRes.data ?? []) as unknown as CommitmentRow[];
+
+    // One summary fetch for all the transcripts we might cite.
+    const candidates = new Map<string, { meeting: RetomaInput; touch: Observation; meetingTouch: Observation | null; chase: string[] }>();
+    for (const m of inWindow) {
+      const matcher = asMatcherMeeting(m);
+
+      // Gate 1 — anything owed (same rows + matcher as the STB prep gate)
+      // means a PREP block covers this meeting; retoma stays out of the way.
+      if (openRows.some(r => commitmentMatchesMeeting(r, matcher))) continue;
+
+      // Gate 2 — material: prior touch with these attendees.
+      const emails = new Set(m.attendeeEmails.map(e => e.toLowerCase()));
+      const mine = observations.filter(o => o.participants.some(p => emails.has(p)));
+      const touch = mine[0];
+      if (!touch) continue;
+      // Bullets always come from the latest TRANSCRIPT, even when a more
+      // recent email is the headline last-touch — "lo último que se habló"
+      // means the conversation, not the thread subject line.
+      const meetingTouch = mine.find(o => o.kind === "Meeting") ?? null;
+
+      const chase = chaseRows
+        .filter(r => commitmentMatchesMeeting(r, matcher))
+        .slice(0, 2)
+        .map(r => {
+          const txt = (r.next_action ?? r.subject).trim();
+          return r.counterparty ? `${r.counterparty}: ${txt}` : txt;
+        });
+
+      candidates.set(m.eventId, { meeting: m, touch, meetingTouch, chase });
+    }
+    if (candidates.size === 0) return out;
+
+    const transcriptIds = [...new Set(
+      [...candidates.values()].map(c => c.meetingTouch?.transcriptId).filter((t): t is string => !!t),
+    )];
+    const summaryByTranscript = new Map<string, string>();
+    if (transcriptIds.length > 0) {
+      const { data: srcs } = await sb
+        .from("sources")
+        .select("source_external_id,processed_summary")
+        .in("source_external_id", transcriptIds);
+      for (const s of (srcs ?? []) as { source_external_id: string | null; processed_summary: string | null }[]) {
+        if (s.source_external_id && s.processed_summary) {
+          summaryByTranscript.set(s.source_external_id, s.processed_summary);
+        }
+      }
+    }
+
+    for (const [eventId, c] of candidates) {
+      out.set(eventId, {
+        eventId,
+        lastTouch: { kind: c.touch.kind, at: c.touch.at, title: c.touch.title },
+        bullets: bulletize(c.meetingTouch?.transcriptId ? summaryByTranscript.get(c.meetingTouch.transcriptId) ?? null : null),
+        waitingOnThem: c.chase,
+      });
+    }
+  } catch (e) {
+    // Retomas are decoration on the agenda — never let them break it, but
+    // never fail silently either (AGENTS.md fallback observability rule).
+    console.warn("[meeting-retomas] DEGRADED: retoma build failed —", e instanceof Error ? e.message : e);
+    return out;
+  }
+  return out;
+}

--- a/src/lib/project-context.ts
+++ b/src/lib/project-context.ts
@@ -31,11 +31,16 @@ export type ProjectContext = {
   project_source: "explicit" | "inferred" | null;
 };
 
-type ProjectRow = {
+/** Minimal project shape the matching primitives operate on. Exported so
+ *  ingestors and backfills can run the SAME conservative inference that
+ *  powers the STB chips — one matcher, one behaviour. */
+export type MatchableProject = {
   id: string;
   notion_id: string | null;
   name: string;
 };
+
+type ProjectRow = MatchableProject;
 
 type ObjectiveRow = {
   id: string;
@@ -77,7 +82,7 @@ function projectMatchesText(project: ProjectRow, textSquash: string, textTokens:
 /** When several projects match, accept only the family case where every
  *  match is an extension of one shortest base name ("Kinko" + "Kinko —
  *  Pre-sale…" → "Kinko"). Genuinely distinct matches → ambiguous → null. */
-function disambiguate(matches: ProjectRow[]): ProjectRow | null {
+function disambiguate(matches: MatchableProject[]): MatchableProject | null {
   if (matches.length === 0) return null;
   if (matches.length === 1) return matches[0];
   const sorted = [...matches].sort((a, b) => squash(primaryName(a.name)).length - squash(primaryName(b.name)).length);
@@ -88,6 +93,33 @@ function disambiguate(matches: ProjectRow[]): ProjectRow | null {
 const EMPTY_CONTEXT: ProjectContext = {
   project_name: null, objective_title: null, objective_tier: null, project_source: null,
 };
+
+/** Active (non-dead) projects, fetched once per caller run. Throws on DB
+ *  error — callers decide their own fail-soft policy. */
+export async function loadActiveProjects(): Promise<MatchableProject[]> {
+  const sb = getSupabaseServerClient();
+  // Status filter runs in JS: SQL `NOT IN` silently drops NULL-status rows.
+  const { data, error } = await sb.from("projects").select("id,notion_id,name,project_status");
+  if (error) throw new Error(`loadActiveProjects: ${error.message}`);
+  const deadProj = new Set(["Archived", "Completed", "Closed", "Cancelled"]);
+  return ((data ?? []) as (MatchableProject & { project_status: string | null })[])
+    .filter(p => !deadProj.has(p.project_status ?? ""));
+}
+
+/**
+ * Conservative name inference: returns the single unambiguous project whose
+ * primary name appears in `text`, or null. Two genuinely distinct matches →
+ * null (a missing link beats a wrong one). Same matcher the STB chips use.
+ */
+export function inferProjectFromText(
+  projects: MatchableProject[],
+  text: string,
+): MatchableProject | null {
+  if (!text.trim() || projects.length === 0) return null;
+  const textSquash = squash(text);
+  const textTokens = tokens(text);
+  return disambiguate(projects.filter(p => projectMatchesText(p, textSquash, textTokens)));
+}
 
 /**
  * Batch-resolve project context for a set of candidates.
@@ -105,15 +137,13 @@ export async function resolveProjectContexts(
   let objectives: ObjectiveRow[] = [];
   try {
     const sb = getSupabaseServerClient();
-    // Status filters run in JS: SQL `NOT IN` silently drops NULL-status rows.
-    const [projRes, objRes] = await Promise.all([
-      sb.from("projects").select("id,notion_id,name,project_status"),
+    // Status filter runs in JS: SQL `NOT IN` silently drops NULL-status rows.
+    const [projList, objRes] = await Promise.all([
+      loadActiveProjects(),
       sb.from("strategic_objectives").select("id,title,tier,status,linked_projects"),
     ]);
-    const deadProj = new Set(["Archived", "Completed", "Closed", "Cancelled"]);
-    const deadObj  = new Set(["achieved", "dropped"]);
-    projects = ((projRes.data ?? []) as (ProjectRow & { project_status: string | null })[])
-      .filter(p => !deadProj.has(p.project_status ?? ""));
+    const deadObj = new Set(["achieved", "dropped"]);
+    projects = projList;
     objectives = ((objRes.data ?? []) as (ObjectiveRow & { status: string | null })[])
       .filter(o => !deadObj.has(o.status ?? ""));
   } catch (e) {
@@ -160,9 +190,7 @@ export async function resolveProjectContexts(
         continue;
       }
     } else if (ref.infer_text) {
-      const textSquash = squash(ref.infer_text);
-      const textTokens = tokens(ref.infer_text);
-      project = disambiguate(projects.filter(p => projectMatchesText(p, textSquash, textTokens)));
+      project = inferProjectFromText(projects, ref.infer_text);
       source = project ? "inferred" : null;
     }
 

--- a/src/lib/project-context.ts
+++ b/src/lib/project-context.ts
@@ -1,0 +1,179 @@
+/**
+ * project-context.ts
+ *
+ * Resolves "which project / strategic objective does this work hang from?"
+ * for Suggested Time Blocks, so every block carries a priority-legible chip
+ * (project · objective tier) instead of forcing Jose to guess.
+ *
+ * Resolution order per candidate:
+ *   1. explicit  — FK ids on the source row (action_items.project_id /
+ *      .strategic_objective_id, loops.parent_project_name). Authoritative.
+ *   2. inferred  — conservative name match between the candidate's text and
+ *      active project names. Only an UNAMBIGUOUS single winner is used;
+ *      two plausible projects → no chip (a missing chip beats a wrong one).
+ *
+ * Objective tier is resolved ONLY through explicit linkage (the candidate's
+ * strategic_objective_id, or a strategic_objectives row whose linked_projects
+ * contains the resolved project). Tier is never inferred from text — an
+ * invented priority is worse than none.
+ *
+ * Fail-soft: any DB error returns an empty map. Context is decoration;
+ * it must never break block generation.
+ */
+
+import { getSupabaseServerClient } from "./supabase-server";
+import type { Candidate } from "./time-block-candidates";
+
+export type ProjectContext = {
+  project_name: string | null;
+  objective_title: string | null;
+  objective_tier: string | null;            // 'high' | 'mid' | 'low'
+  project_source: "explicit" | "inferred" | null;
+};
+
+type ProjectRow = {
+  id: string;
+  notion_id: string | null;
+  name: string;
+};
+
+type ObjectiveRow = {
+  id: string;
+  title: string;
+  tier: string;
+  linked_projects: string[] | null;
+};
+
+/** Accent-insensitive lowercase with everything non-alphanumeric removed —
+ *  "Reuse for All" and "ReuseForAll" both squash to "reuseforall". */
+function squash(s: string): string {
+  return s.normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function tokens(s: string): Set<string> {
+  return new Set(
+    s.normalize("NFD").replace(/[̀-ͯ]/g, "")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(t => t.length >= 3),
+  );
+}
+
+/** The matchable part of a project name: qualifiers after a dash/em-dash or
+ *  in parentheses are dropped ("Auto Mercado - Fase 2" matches on
+ *  "Auto Mercado"; "Kinko — Pre-sale (Uruguay…)" matches on "Kinko"). */
+function primaryName(name: string): string {
+  return name.split(/\s+[-–—]\s+|\(/)[0].trim();
+}
+
+function projectMatchesText(project: ProjectRow, textSquash: string, textTokens: Set<string>): boolean {
+  const prim = primaryName(project.name);
+  const primSquash = squash(prim);
+  if (primSquash.length >= 5) return textSquash.includes(primSquash);
+  if (primSquash.length >= 4) return textTokens.has(primSquash);
+  return false; // names under 4 chars are too collision-prone to infer from
+}
+
+/** When several projects match, accept only the family case where every
+ *  match is an extension of one shortest base name ("Kinko" + "Kinko —
+ *  Pre-sale…" → "Kinko"). Genuinely distinct matches → ambiguous → null. */
+function disambiguate(matches: ProjectRow[]): ProjectRow | null {
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0];
+  const sorted = [...matches].sort((a, b) => squash(primaryName(a.name)).length - squash(primaryName(b.name)).length);
+  const base = squash(primaryName(sorted[0].name));
+  return sorted.every(p => squash(primaryName(p.name)).startsWith(base)) ? sorted[0] : null;
+}
+
+const EMPTY_CONTEXT: ProjectContext = {
+  project_name: null, objective_title: null, objective_tier: null, project_source: null,
+};
+
+/**
+ * Batch-resolve project context for a set of candidates.
+ * Returns a map keyed by candidate fingerprint; candidates with no
+ * resolvable context map to EMPTY_CONTEXT semantics (all nulls).
+ */
+export async function resolveProjectContexts(
+  candidates: Candidate[],
+): Promise<Map<string, ProjectContext>> {
+  const out = new Map<string, ProjectContext>();
+  const relevant = candidates.filter(c => c.project_ref);
+  if (relevant.length === 0) return out;
+
+  let projects: ProjectRow[] = [];
+  let objectives: ObjectiveRow[] = [];
+  try {
+    const sb = getSupabaseServerClient();
+    // Status filters run in JS: SQL `NOT IN` silently drops NULL-status rows.
+    const [projRes, objRes] = await Promise.all([
+      sb.from("projects").select("id,notion_id,name,project_status"),
+      sb.from("strategic_objectives").select("id,title,tier,status,linked_projects"),
+    ]);
+    const deadProj = new Set(["Archived", "Completed", "Closed", "Cancelled"]);
+    const deadObj  = new Set(["achieved", "dropped"]);
+    projects = ((projRes.data ?? []) as (ProjectRow & { project_status: string | null })[])
+      .filter(p => !deadProj.has(p.project_status ?? ""));
+    objectives = ((objRes.data ?? []) as (ObjectiveRow & { status: string | null })[])
+      .filter(o => !deadObj.has(o.status ?? ""));
+  } catch (e) {
+    // Fail-soft but visible (AGENTS.md fallback observability rule): blocks
+    // render without chips this round, and the logs say why.
+    console.warn("[project-context] DEGRADED: context resolution failed —", e instanceof Error ? e.message : e);
+    return out;
+  }
+  if (projects.length === 0) return out;
+
+  const byUuid = new Map(projects.map(p => [p.id, p]));
+  const byNameSquash = new Map(projects.map(p => [squash(p.name), p]));
+  const objByUuid = new Map(objectives.map(o => [o.id, o]));
+
+  function objectiveForProject(p: ProjectRow): ObjectiveRow | null {
+    for (const o of objectives) {
+      const linked = o.linked_projects ?? [];
+      if (linked.includes(p.id) || (p.notion_id && linked.includes(p.notion_id))) return o;
+    }
+    return null;
+  }
+
+  for (const c of relevant) {
+    const ref = c.project_ref!;
+    let project: ProjectRow | null = null;
+    let source: ProjectContext["project_source"] = null;
+    let objective: ObjectiveRow | null = null;
+
+    if (ref.objective_id && objByUuid.has(ref.objective_id)) {
+      objective = objByUuid.get(ref.objective_id)!;
+    }
+    if (ref.project_id && byUuid.has(ref.project_id)) {
+      project = byUuid.get(ref.project_id)!;
+      source = "explicit";
+    } else if (ref.name_hint) {
+      // Loops store the project NAME, not the uuid — trust it as explicit.
+      project = byNameSquash.get(squash(ref.name_hint)) ?? null;
+      source = "explicit";
+      if (!project) {
+        out.set(c.fingerprint, {
+          project_name: ref.name_hint, objective_title: objective?.title ?? null,
+          objective_tier: objective?.tier ?? null, project_source: "explicit",
+        });
+        continue;
+      }
+    } else if (ref.infer_text) {
+      const textSquash = squash(ref.infer_text);
+      const textTokens = tokens(ref.infer_text);
+      project = disambiguate(projects.filter(p => projectMatchesText(p, textSquash, textTokens)));
+      source = project ? "inferred" : null;
+    }
+
+    if (!objective && project) objective = objectiveForProject(project);
+
+    out.set(c.fingerprint, project || objective ? {
+      project_name:    project?.name ?? null,
+      objective_title: objective?.title ?? null,
+      objective_tier:  objective?.tier ?? null,
+      project_source:  source,
+    } : EMPTY_CONTEXT);
+  }
+  return out;
+}

--- a/src/lib/time-block-candidates.ts
+++ b/src/lib/time-block-candidates.ts
@@ -35,6 +35,14 @@ export type Candidate = {
   fingerprint: string;
   /** If set, the assigned slot must satisfy this window. Used for prep/follow-up. */
   hard_time_constraint?: { kind: "before" | "after"; reference: Date; withinMs: number };
+  /** Hints for resolveProjectContexts — explicit FK ids when the source row
+   *  carries them, free text for conservative name inference otherwise. */
+  project_ref?: {
+    project_id?: string | null;
+    objective_id?: string | null;
+    name_hint?: string | null;
+    infer_text?: string | null;
+  };
 };
 
 // ─── Loops → Candidates ──────────────────────────────────────────────────────
@@ -52,6 +60,7 @@ type LoopRow = {
   linked_entity_name: string;
   review_url: string | null;
   intervention_moment: string;
+  parent_project_name: string | null;
 };
 
 function loopDuration(loopType: string): number {
@@ -122,7 +131,7 @@ export async function candidatesFromLoops(limit = 20): Promise<Candidate[]> {
   const sb = getSupabaseServerClient();
   const { data, error } = await sb
     .from("loops")
-    .select("id,title,loop_type,status,priority_score,founder_owned,due_at,linked_entity_type,linked_entity_id,linked_entity_name,review_url,intervention_moment")
+    .select("id,title,loop_type,status,priority_score,founder_owned,due_at,linked_entity_type,linked_entity_id,linked_entity_name,review_url,intervention_moment,parent_project_name")
     .in("status", ["open", "in_progress", "reopened"])
     .order("priority_score", { ascending: false, nullsFirst: false })
     .limit(limit);
@@ -178,6 +187,10 @@ export async function candidatesFromLoops(limit = 20): Promise<Candidate[]> {
       why_now:          loopWhyNow(l, dueSoonDays),
       expected_outcome: loopExpectedOutcome(l),
       fingerprint:      `loop:${l.id}:${loopTaskType(l.loop_type)}`,
+      project_ref:      {
+        name_hint:  l.parent_project_name,
+        infer_text: `${l.title} ${l.linked_entity_name}`,
+      },
     });
   }
   return out;
@@ -237,6 +250,7 @@ export async function candidatesFromOpportunities(
       why_now:          `Active opportunity (score ${o.opportunity_score ?? "—"}/100)${o.follow_up_status === "Needed" ? " · follow-up flagged" : ""}.`,
       expected_outcome: `Next step executed: ${step.length > 140 ? step.slice(0, 140) + "…" : step}`,
       fingerprint:      `opportunity:${o.notion_id}:deep_work`,
+      project_ref:      { infer_text: `${o.title} ${o.org_name ?? ""}` },
     });
   }
   return out;
@@ -270,6 +284,8 @@ export type CommitmentRow = {
   first_surfaced_at: string | null;
   source_type:       string;
   source_url:        string | null;
+  project_id:        string | null;
+  strategic_objective_id: string | null;
 };
 
 /** Intents that can justify an individual time block. `reply` belongs to the
@@ -304,7 +320,7 @@ export async function fetchOpenCommitmentRows(limit = 50): Promise<CommitmentRow
   const sb = getSupabaseServerClient();
   const { data, error } = await sb
     .from("action_items")
-    .select("id, subject, counterparty, next_action, intent, effort, deadline, priority_score, last_motion_at, first_surfaced_at, source_type, source_url")
+    .select("id, subject, counterparty, next_action, intent, effort, deadline, priority_score, last_motion_at, first_surfaced_at, source_type, source_url, project_id, strategic_objective_id")
     .eq("status", "open")
     .eq("ball_in_court", "jose")
     .in("source_type", ["fireflies", "gmail", "drive", "evidence_derived"])
@@ -330,8 +346,11 @@ function normTokens(s: string | null | undefined): string[] {
  * matches an attendee (display name or email local part) or the meeting
  * title, or when the meeting title overlaps the commitment subject on ≥2
  * meaningful tokens (catches org/project-named meetings).
+ *
+ * Exported for meeting-retomas, which uses the SAME matcher so the
+ * prep-vs-retoma split can never disagree about whether something is owed.
  */
-function commitmentMatchesMeeting(r: CommitmentRow, m: UpcomingMeeting): boolean {
+export function commitmentMatchesMeeting(r: CommitmentRow, m: UpcomingMeeting): boolean {
   const cpTokens = normTokens(r.counterparty);
   const titleTokens = normTokens(m.title);
   const titleSet = new Set(titleTokens);
@@ -453,6 +472,11 @@ export function candidatesFromCommitments(
       why_now:          why.join(" · ") + ".",
       expected_outcome: commitmentOutcome(r),
       fingerprint:      `commitment:${r.id}`,
+      project_ref:      {
+        project_id:   r.project_id,
+        objective_id: r.strategic_objective_id,
+        infer_text:   `${r.subject} ${r.next_action ?? ""} ${r.counterparty ?? ""}`,
+      },
       // Bind to "before the accountability meeting" only when there is enough
       // room to actually find a slot; binding a meeting <48h out would drop
       // the candidate entirely whenever the day is already packed.
@@ -524,13 +548,19 @@ export type PrepOptions = {
 };
 
 /**
- * Prep candidates — only when there is something concrete to prepare FROM.
- * Material gates (any):
- *   A. Open commitments involving an attendee / this meeting's subject —
- *      "you walk in owing them something".
- *   B. A real agenda in the event description.
- *   C. A VIP attendee (explicit human 'VIP' tag — high stakes by definition).
- * A recurring internal sync with none of the above gets NO prep block.
+ * Prep candidates — emitted ONLY when Jose walks in owing the meeting
+ * something concrete: an open commitment involving an attendee or this
+ * meeting's subject. Owed work is the one honest reason to reserve
+ * calendar time, because it is the only case where there is both material
+ * to prepare FROM and an output of Jose's to prepare.
+ *
+ * An agenda alone or a VIP attendee does NOT create a block any more:
+ * with no task of Jose's there is nothing to prepare, and the old blocks
+ * degenerated into generic filler ("Agenda reviewed; a position decided").
+ * Those meetings get a Retoma card next to the day's agenda instead
+ * (src/lib/meeting-retomas.ts) — a read-before-you-walk-in pointer that
+ * costs zero calendar time. Agenda and VIP survive only as boosters on
+ * blocks that earned their place through owed work.
  */
 export function candidatesFromMeetings(
   meetings: UpcomingMeeting[],
@@ -550,33 +580,23 @@ export function candidatesFromMeetings(
     // The event stays busy for slot-finding, but no prep task is emitted.
     if (cls.is_personal) continue;
 
-    const owed   = opts.openCommitments.filter(r => commitmentMatchesMeeting(r, m));
-    const agenda = hasRealAgenda(m.description);
-    const vip    = cls.has_vip;
-    if (owed.length === 0 && !agenda && !vip) continue;          // no material → no prep
+    const owed = opts.openCommitments.filter(r => commitmentMatchesMeeting(r, m));
+    if (owed.length === 0) continue;             // nothing owed → no prep block
+
+    const agenda = hasRealAgenda(m.description); // booster, never a gate
+    const vip    = cls.has_vip;                  // booster, never a gate
 
     const timeLabel = fmtMeetingTime(m.start, opts.timezone);
     const whyParts: string[] = [];
-    let confidence = 0;
-    let urgency = daysUntil <= 1 ? 75 : 62;
+    let urgency = (daysUntil <= 1 ? 75 : 62) + 12;
 
-    if (owed.length > 0) {
-      const first = owed[0];
-      const firstTitle = (first.next_action ?? first.subject).trim();
-      const shortTitle = firstTitle.length > 60 ? firstTitle.slice(0, 57) + "…" : firstTitle;
-      whyParts.push(`Open with ${first.counterparty ?? "the counterpart"}: "${shortTitle}"${owed.length > 1 ? ` +${owed.length - 1} more` : ""}`);
-      confidence = Math.max(confidence, 85);
-      urgency += 12;
-    }
-    if (agenda) { whyParts.push("agenda set"); confidence = Math.max(confidence, 70); }
-    if (vip)    { whyParts.push("VIP attendee — high stakes"); confidence = Math.max(confidence, 65); urgency += 8; }
+    const first = owed[0];
+    const firstTitle = (first.next_action ?? first.subject).trim();
+    const shortTitle = firstTitle.length > 60 ? firstTitle.slice(0, 57) + "…" : firstTitle;
+    whyParts.push(`Open with ${first.counterparty ?? "the counterpart"}: "${shortTitle}"${owed.length > 1 ? ` +${owed.length - 1} more` : ""}`);
+    if (agenda) whyParts.push("agenda set");
+    if (vip)    { whyParts.push("VIP attendee — high stakes"); urgency += 8; }
     whyParts.push(`meeting ${timeLabel} · ${cls.confirmed_count} confirmed`);
-
-    const outcome = owed.length > 0
-      ? `Walk in with the ${owed.length} open item${owed.length === 1 ? "" : "s"} addressed or an answer ready.`
-      : agenda
-      ? "Agenda reviewed; a position decided for each item."
-      : "Context reviewed; objectives for the meeting decided.";
 
     out.push({
       title:            `Prep for "${m.title}"`,
@@ -586,11 +606,16 @@ export function candidatesFromMeetings(
       duration_min:     owed.length >= 2 || agenda ? 45 : 40,
       task_type:        "prep",
       urgency_score:    Math.min(100, urgency),
-      confidence_score: confidence,
+      confidence_score: 85,
       why_now:          whyParts.join(" · ") + ".",
-      expected_outcome: outcome,
+      expected_outcome: `Walk in with the ${owed.length} open item${owed.length === 1 ? "" : "s"} addressed or an answer ready.`,
       fingerprint:      `meeting_prep:${seriesKey(m.id)}:prep`,
       hard_time_constraint: { kind: "before", reference: m.start, withinMs: 24 * 3600_000 },
+      project_ref:      {
+        project_id: first.project_id,
+        objective_id: first.strategic_objective_id,
+        infer_text: `${m.title} ${first.subject}`,
+      },
     });
   }
   return out;

--- a/supabase/migrations/20260611130000_stb_project_context.sql
+++ b/supabase/migrations/20260611130000_stb_project_context.sql
@@ -1,0 +1,13 @@
+-- Suggested Time Blocks — project / objective context chip.
+-- Every block should answer "which project does this hang from, and what
+-- tier of the plan does that project serve?" at a glance.
+-- Resolution happens at generation time (src/lib/project-context.ts):
+-- explicit FK linkage when the source row carries it, conservative
+-- name inference otherwise. NULLs mean "could not resolve honestly".
+
+alter table public.suggested_time_blocks
+  add column if not exists project_name    text,
+  add column if not exists objective_title text,
+  add column if not exists objective_tier  text,
+  add column if not exists project_source  text
+    check (project_source in ('explicit', 'inferred'));


### PR DESCRIPTION
Systemic fix: action_items.project_id stamped at ingest (fireflies@1.3.0 explicit evidence linkage + inference; gmail@1.4.0 subject inference + unambiguous sender project), fill-only linkage patch in persist.ts, one-shot backfill route (already executed: 3/18 open rows linked), and /admin/plan drawer multi-select to curate strategic_objectives.linked_projects (only path that activates tier on STB chips). Also carries e484ffe (STB v2.1 prep/retoma/chips) which was not yet on main. tsc clean; verified locally against prod Supabase via /api/stb-debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)