### PR TITLE
fix(routines): admin-session trigger 401 — check email, not just Clerk userId

### DIFF
--- a/src/app/api/agent-scorecard/route.ts
+++ b/src/app/api/agent-scorecard/route.ts
@@ -14,8 +14,8 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { isAdminUser } from "@/lib/clients";
+import { currentUser } from "@clerk/nextjs/server";
+import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { withRoutineLog } from "@/lib/routine-log";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { createPageWithMirror } from "@/lib/notion-mirror-push";
@@ -32,8 +32,13 @@ async function authCheck(req: NextRequest): Promise<boolean> {
   if (expected && agentKey === expected) return true;
   if (expected && cronToken === `Bearer ${expected}`) return true;
   try {
-    const { userId } = await auth();
-    if (userId && isAdminUser(userId)) return true;
+    // Check id AND email — the production Clerk userId differs from dev, so
+    // admin access must also resolve via ADMIN_EMAILS (mirrors adminGuardApi).
+    const user = await currentUser();
+    if (user) {
+      const email = user.primaryEmailAddress?.emailAddress ?? "";
+      if (isAdminUser(user.id) || isAdminEmail(email)) return true;
+    }
   } catch { /* no-op */ }
   return false;
 }

--- a/src/app/api/competitive-monitor/route.ts
+++ b/src/app/api/competitive-monitor/route.ts
@@ -22,9 +22,10 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+// TODO phase-6: migrate read source to Supabase watchlist_entities + competitive_intel
 import { Client } from "@notionhq/client";
-import { auth } from "@clerk/nextjs/server";
-import { isAdminUser } from "@/lib/clients";
+import { currentUser } from "@clerk/nextjs/server";
+import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { withRoutineLog } from "@/lib/routine-log";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 
@@ -47,8 +48,13 @@ async function authCheck(req: NextRequest): Promise<boolean> {
   if (expected && agentKey === expected)              return true;
   if (expected && cronToken === `Bearer ${expected}`) return true;
   try {
-    const { userId } = await auth();
-    if (userId && isAdminUser(userId)) return true;
+    // Check id AND email — the production Clerk userId differs from dev, so
+    // admin access must also resolve via ADMIN_EMAILS (mirrors adminGuardApi).
+    const user = await currentUser();
+    if (user) {
+      const email = user.primaryEmailAddress?.emailAddress ?? "";
+      if (isAdminUser(user.id) || isAdminEmail(email)) return true;
+    }
   } catch { /* no-op */ }
   return false;
 }

--- a/src/app/api/grant-monitor/route.ts
+++ b/src/app/api/grant-monitor/route.ts
@@ -25,9 +25,10 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+// TODO phase-6: migrate read source to Supabase opportunities + projects
 import { Client } from "@notionhq/client";
-import { auth } from "@clerk/nextjs/server";
-import { isAdminUser } from "@/lib/clients";
+import { currentUser } from "@clerk/nextjs/server";
+import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { withRoutineLog } from "@/lib/routine-log";
 import { createPageWithMirror } from "@/lib/notion-mirror-push";
 
@@ -50,8 +51,13 @@ async function authCheck(req: NextRequest): Promise<boolean> {
   if (expected && agentKey === expected) return true;
   if (expected && cronToken === `Bearer ${expected}`) return true;
   try {
-    const { userId } = await auth();
-    if (userId && isAdminUser(userId)) return true;
+    // Check id AND email — the production Clerk userId differs from dev, so
+    // admin access must also resolve via ADMIN_EMAILS (mirrors adminGuardApi).
+    const user = await currentUser();
+    if (user) {
+      const email = user.primaryEmailAddress?.emailAddress ?? "";
+      if (isAdminUser(user.id) || isAdminEmail(email)) return true;
+    }
   } catch { /* no-op */ }
   return false;
 }

--- a/src/app/api/grant-radar/route.ts
+++ b/src/app/api/grant-radar/route.ts
@@ -17,9 +17,10 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+// TODO phase-6: migrate read source to Supabase projects
 import { Client } from "@notionhq/client";
-import { auth } from "@clerk/nextjs/server";
-import { isAdminUser } from "@/lib/clients";
+import { currentUser } from "@clerk/nextjs/server";
+import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { withRoutineLog } from "@/lib/routine-log";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 
@@ -42,8 +43,13 @@ async function authCheck(req: NextRequest): Promise<boolean> {
   if (expected && agentKey === expected)              return true;
   if (expected && cronToken === `Bearer ${expected}`) return true;
   try {
-    const { userId } = await auth();
-    if (userId && isAdminUser(userId)) return true;
+    // Check id AND email — the production Clerk userId differs from dev, so
+    // admin access must also resolve via ADMIN_EMAILS (mirrors adminGuardApi).
+    const user = await currentUser();
+    if (user) {
+      const email = user.primaryEmailAddress?.emailAddress ?? "";
+      if (isAdminUser(user.id) || isAdminEmail(email)) return true;
+    }
   } catch { /* no-op */ }
   return false;
 }

--- a/src/app/api/portfolio-health/route.ts
+++ b/src/app/api/portfolio-health/route.ts
@@ -22,9 +22,10 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+// TODO phase-6: migrate read source to Supabase opportunities
 import { Client } from "@notionhq/client";
-import { auth } from "@clerk/nextjs/server";
-import { isAdminUser } from "@/lib/clients";
+import { currentUser } from "@clerk/nextjs/server";
+import { isAdminUser, isAdminEmail } from "@/lib/clients";
 import { withRoutineLog } from "@/lib/routine-log";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { createPageWithMirror } from "@/lib/notion-mirror-push";
@@ -45,8 +46,13 @@ async function authCheck(req: NextRequest): Promise<boolean> {
   if (expected && agentKey === expected) return true;
   if (expected && cronToken === `Bearer ${expected}`) return true;
   try {
-    const { userId } = await auth();
-    if (userId && isAdminUser(userId)) return true;
+    // Check id AND email — the production Clerk userId differs from dev, so
+    // admin access must also resolve via ADMIN_EMAILS (mirrors adminGuardApi).
+    const user = await currentUser();
+    if (user) {
+      const email = user.primaryEmailAddress?.emailAddress ?? "";
+      if (isAdminUser(user.id) || isAdminEmail(email)) return true;
+    }
   } catch { /* no-op */ }
   return false;
 }


### PR DESCRIPTION
## Problema

El routine **competitive-monitor** fallaba con `error · Unauthorized` (~17ms) al dispararlo desde el botón **Run scan** del Hall. La causa: su `authCheck` propio solo validaba `isAdminUser(userId)` vía `auth()`. En producción el Clerk `userId` difiere del de dev y **no** está en `ADMIN_USER_IDS`; el acceso admin resuelve por `ADMIN_EMAILS` — que este check nunca miraba.

El cron de las 07:00 no se veía afectado porque usa el header `Authorization: Bearer CRON_SECRET`. Solo fallaban los triggers con sesión admin (los botones "Run" del panel).

## Fix (sistémico)

Alinear la rama de sesión con `adminGuardApi`: `currentUser()` + `(isAdminUser(id) || isAdminEmail(email))`.

Aplicado al routine reportado **y a 4 hermanos con el bug idéntico** (mismo patrón id-only):

- `competitive-monitor`
- `grant-radar`
- `grant-monitor`
- `portfolio-health`
- `agent-scorecard`

`approve-project-update` ya usaba `adminGuardApi` — sin cambios.

## Verificación

- `tsc --noEmit` limpio.
- Sin usos residuales de `auth()` tras el swap de import.
- Verificación end-to-end en producción: disparar **Run scan** debe devolver 200 en vez de 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)